### PR TITLE
fix: append https to vapor dmlEndpoint

### DIFF
--- a/web/src/data/recoil.ts
+++ b/web/src/data/recoil.ts
@@ -101,7 +101,7 @@ export const vaporConnectionConfig = selector<ConnectionConfig | undefined>({
           const data = (await response.json()) as VaporClusterConnectionConfig;
 
           return {
-            host: data.endpoint,
+            host: "https://" + data.endpoint,
             user: data.user,
             password: data.password,
             database: get(connectionDatabase),


### PR DESCRIPTION
vapor and the managment API "endpoint" fields both return the host for the field without a protocol. This change modifies the demo to assume vapor endpoints will always be "https".

Alternatively, if we think vapor should only operate over HTTP, then I'm cool with changing vapor to always return a URL for endpoint. WDYT?

This change fixes the error where we're attempting to exec on the following URL since it's assumed relative without the protocol.

`https://digital-marketing.labs.singlestore.com/svc-9da74430-d50c-4346-a566-94265d6193ed-ddl.aws-oregon-2.svc.singlestore.com/api/v1/exec`