### PR TITLE
fix: http api renamed to data api

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This demo makes extensive use of stored procedures which contain all of the logi
 
 # Web application
 
-The [user interface][demo] is implemented as a single-page web application which runs entirely in the browser. The interface connects to any SingleStore cluster which has the [HTTP API][http-api] enabled. To get started quickly, we recommend either using our [Docker image][ciab] or the [SingleStore Managed Service][portal].
+The [user interface][demo] is implemented as a single-page web application which runs entirely in the browser. The interface connects to any SingleStore cluster which has the [Data API][data-api] enabled. To get started quickly, we recommend either using our [Docker image][ciab] or the [SingleStore Managed Service][portal].
 
 ## Quickstart: Docker Image
 
@@ -119,9 +119,8 @@ The [user interface][demo] is implemented as a single-page web application which
 
 1. [Sign up][try-free] for $500 in free managed service credits.
 2. Create a S-00 sized cluster in [the portal][portal]
-3. Contact support (see contact-us button in top right) to ask for the HTTP API to be enabled on your cluster
-4. Open the [Digital Marketing demo][demo] in Chrome or Firefox
-5. Plug in the connection details (replacing placeholders as needed):
+3. Open the [Digital Marketing demo][demo] in Chrome or Firefox
+4. Plug in the connection details (replacing placeholders as needed):
    
 | Key         | Value                          |
 | ----------- | ------------------------------ |
@@ -131,6 +130,6 @@ The [user interface][demo] is implemented as a single-page web application which
 
 [try-free]: https://www.singlestore.com/try-free/
 [demo]: https://digital-marketing.labs.singlestore.com
-[http-api]: https://docs.singlestore.com/docs/http-api/
+[data-api]: https://docs.singlestore.com/managed-service/en/reference/data-api.html
 [ciab]: https://github.com/memsql/deployment-docker
 [portal]: https://portal.singlestore.com/

--- a/web/src/components/DatabaseConfigForm.tsx
+++ b/web/src/components/DatabaseConfigForm.tsx
@@ -35,7 +35,7 @@ export const DatabaseConfigForm = ({
           <MarkdownText>
             {`
               The protocol (http, https), host, and port for the SingleStore
-              [HTTP API][1].
+              [Data API][1].
 
               [1]: https://docs.singlestore.com/docs/http-api/
             `}

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -137,14 +137,10 @@ const ConnectionSection = ({
       left={
         <MarkdownText>
           {`
-            This demo requires a connection to SingleStore's HTTP API. Please
+            This demo requires a connection to SingleStore's Data API. Please
             ensure the connection details on the right are correct.
             
-            **Note**: The HTTP API may need to be enabled on your SingleStore
-            cluster. To do so please see [our documentation][1] or contact
-            support for assistance.
-            
-            [1]: https://docs.singlestore.com/docs/http-api/
+            [1]: https://docs.singlestore.com/managed-service/en/reference/data-api.html
           `}
         </MarkdownText>
       }


### PR DESCRIPTION
Replaced instances of referring to the Data API as the HTTP API.
Removed text about contacting support to enable the Data API now that it is enabled by default.