### PR TITLE
Define mandatory "OG" tag "Type" In headers for OG Graph

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="src/assets/singlestore-logo-holo.svg" type="image/png" />
     <meta property='og:title' content='Real-Time Digital Marketing'/>
+    <meta property='og:type' content='image:png'/>
     <meta property='og:description' content="Exciting MarTech demo application from SingleStoreDB showcasing its capability in powering concurrently ingest, transactional and analytical workloads thanks to its universal store. As a demo app, it gives you an overview of what's possible when using SingleStoreDB for your own projects, digital-marketing.labs.singlestore.com.
     #SingleStoreDB #database #digitalmarketing #appdevelopment"/>
     <meta property='og:image' content="https://digital-marketing.labs.singlestore.com/socialPostLinkedIn.png"/>
@@ -12,6 +13,7 @@
     <meta property='twitter:title' content='Real-Time Digital Marketing'/>
     <meta property='twitter:description' content="Exciting MarTech demo application from SingleStoreDB showcasing its capability in powering concurrently ingest, transactional and analytical workloads thanks to its universal store. As a demo app, it gives you an overview of what's possible when using SingleStoreDB for your own projects, digital-marketing.labs.singlestore.com.
     #SingleStoreDB #database #digitalmarketing #appdevelopment"/>
+    <meta property='twitter:type' content='image:png'/>
     <meta property='twitter:image' content="https://digital-marketing.labs.singlestore.com/socialPostLinkedIn.png"/>
     <meta property='twitter:url' content='https://digital-marketing.labs.singlestore.com/'/>
     <title>SingleStore: Real-Time Digital Marketing Demo</title>


### PR DESCRIPTION
## Summary

As per og documentation 4 og tags are compulsory for OG graph to work. We where missing "type". The MR tends to address the same

Docs - https://ogp.me/#types

## Test Plan

The MR changes can be tested after merging to master

## Changes

1. index.html new Meta OG tag of type "type" in headers

## Subscribers

@mivasconcelos @TitoGrine 