### PR TITLE
Make `micro` the default dataset size 

### DIFF
--- a/web/src/scalefactors.ts
+++ b/web/src/scalefactors.ts
@@ -21,7 +21,7 @@ export const ScaleFactors: Array<ScaleFactor> = [
   {
     name: "s00",
     maxRows: 10_000_000,
-    prefix: "v2/100k-2p",
+    prefix: "v2/10k-2p",
     partitions: 2,
   },
   {
@@ -66,7 +66,7 @@ export const ScaleFactors: Array<ScaleFactor> = [
 export const getScaleFactor = (name: string): ScaleFactor =>
   ScaleFactors.find((sf) => sf.name === name) || ScaleFactors[0];
 
-export const defaultScaleFactor = getScaleFactor("s00");
+export const defaultScaleFactor = getScaleFactor("micro");
 
 export const pickScaleFactor = (numPartitions: number): ScaleFactor => {
   // pick the scale factor with the largest number of partitions <= numPartitions


### PR DESCRIPTION
We want to use the `micro` size since the `100k-2p` is too heavy for an s00 cluster. We should also reduce the size defined for the s00 for consistency.

Test plan:
- connect to the workspace without the `martech` dataset loaded
- create the DB
- go to the pipelines page on Customer Portal and ensure they were created from the `1k-2p` bucket
![screenshot-2023-03-21-15-09-09](https://user-images.githubusercontent.com/72758386/226653319-cdfea520-5009-4288-ae19-92aa7b5321e4.png)
