### PR TITLE
Bug fix: Avoid homepage popup and state loss of variables due to reload

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,7 +18,7 @@ import { Footer } from "@/components/Footer";
 import { Nav } from "@/components/navBar/Nav";
 import { AnalyticsDashboard } from "@/pages/Analytics";
 import { Configure } from "@/pages/Configure";
-import { NotificationsMap } from "@/pages/Dashboard";
+import { Dashboard } from "@/pages/Dashboard";
 import { HomePage } from "@/pages/HomePage";
 import { useConnectionState } from "@/view/hooks/hooks";
 
@@ -91,9 +91,9 @@ const PrivateRoute: React.FC<{ children: React.ReactElement }> = ({
 }) => {
   // Private routes will ensure user is connected to singlestore before using the route.
   // Will redirect to connection page in case user in not connected.
-  const { connected } = useConnectionState();
+  const { connected, isValidatingConnection } = useConnectionState();
 
-  if (!connected) {
+  if (!connected && !isValidatingConnection) {
     return <Navigate to="/" />;
   }
 
@@ -111,11 +111,18 @@ const Analytics = ({ children }: { children: React.ReactNode }) => {
 };
 
 const LayoutContainer = ({ children }: { children: React.ReactNode }) => {
+  const {connected, isValidatingConnection } = useConnectionState();
+  let childComponent = <Loader size="large" centered />;
+
+  if (connected || !isValidatingConnection) {
+    childComponent = <>{children}</>;
+  }
+
   return (
     <>
       <Nav />
       <Box flex="1" paddingTop="3px">
-        {children}
+        {childComponent}
       </Box>
       <Footer />
     </>
@@ -130,7 +137,7 @@ const RoutesBlock = () => {
         path="/dashboard"
         element={
           <PrivateRoute>
-            <NotificationsMap />
+            <Dashboard />
           </PrivateRoute>
         }
       />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -111,7 +111,7 @@ const Analytics = ({ children }: { children: React.ReactNode }) => {
 };
 
 const LayoutContainer = ({ children }: { children: React.ReactNode }) => {
-  const {connected, isValidatingConnection } = useConnectionState();
+  const { connected, isValidatingConnection } = useConnectionState();
   let childComponent = <Loader size="large" centered />;
 
   if (connected || !isValidatingConnection) {

--- a/web/src/data/constants.ts
+++ b/web/src/data/constants.ts
@@ -2,7 +2,7 @@ import { City } from "@/data/queries";
 
 // The selectableCities variable hardcodes cities details that user can select.
 // Make sure the values here matches the values stored in worldcities database in martech.
-export const selectableCitiesData: Array<City> = [
+export const SELECTABLE_CITIES_DATA: Array<City> = [
   {
     id: 14,
     name: "Dubai",
@@ -12,7 +12,7 @@ export const selectableCitiesData: Array<City> = [
   },
   {
     id: 120658,
-    name: "New York",
+    name: "New York City",
     centerLat: 40.71427003,
     centerLon: -74.00597003,
     diameter: 0.4,

--- a/web/src/data/offers.ts
+++ b/web/src/data/offers.ts
@@ -17,7 +17,7 @@ import VENDORS from "@/static-data/vendors.json";
 export const DEFAULT_CITY = {
   id: 120658,
   name: "New York City",
-  lonlat: <[number, number]>[-73.993562, 40.727063],
+  lonlat: <[number, number]>[-74.00597003, 40.71427003],
   diameter: 0.04,
 };
 

--- a/web/src/data/recoil.ts
+++ b/web/src/data/recoil.ts
@@ -5,7 +5,7 @@ import { trackAnalyticsEvent } from "@/analytics";
 import { ConnectionConfig } from "@/data/client";
 
 import { defaultScaleFactor, ScaleFactor, ScaleFactors } from "../scalefactors";
-import { City } from "./queries";
+import { City, getCities } from "./queries";
 
 type LocalStorageEffectConfig<T> = {
   encode: (v: T) => string;
@@ -60,9 +60,23 @@ export const selectedCity = atom({
   default: -1,
 });
 
+export const defaultSelectedCities = selector<Array<City>>({
+  key: "defaultSelectedCities",
+  get: async ({get}) => {
+    const config = get(connectionConfig);
+    let selectedCities: Array<City> = [];
+    try {
+      selectedCities = await getCities(config);
+    } catch (error) {
+      throw error;
+    }
+    return selectedCities;
+  }
+});
+
 export const selectedCities = atom<Array<City>>({
   key: "selectedCities",
-  default: [],
+  default: defaultSelectedCities,
 });
 
 export const isUpdatingCities = atom({

--- a/web/src/data/recoil.ts
+++ b/web/src/data/recoil.ts
@@ -68,7 +68,8 @@ export const defaultSelectedCities = selector<Array<City>>({
     try {
       selectedCities = await getCities(config);
     } catch (error) {
-      throw error;
+      selectedCities = [];
+      console.log('Failed to fetch selected cities details from the Database.');
     }
     return selectedCities;
   }

--- a/web/src/data/recoil.ts
+++ b/web/src/data/recoil.ts
@@ -49,12 +49,6 @@ export const showWelcomeMessage = atom({
   effects: [localStorageEffect()],
 });
 
-export const connectedToDB = atom({
-  key: "connectedToDB",
-  default: false,
-  effects: [localStorageEffect()]
-});
-
 export const userSessionID = atom({
   key: "userID",
   default: uuidv4(),
@@ -69,7 +63,6 @@ export const selectedCity = atom({
 export const selectedCities = atom<Array<City>>({
   key: "selectedCities",
   default: [],
-  effects: [localStorageEffect()]
 });
 
 export const isUpdatingCities = atom({

--- a/web/src/data/recoil.ts
+++ b/web/src/data/recoil.ts
@@ -49,6 +49,12 @@ export const showWelcomeMessage = atom({
   effects: [localStorageEffect()],
 });
 
+export const connectedToDB = atom({
+  key: "connectedToDB",
+  default: false,
+  effects: [localStorageEffect()]
+});
+
 export const userSessionID = atom({
   key: "userID",
   default: uuidv4(),
@@ -58,7 +64,6 @@ export const userSessionID = atom({
 export const selectedCity = atom({
   key: "selectedCity",
   default: -1,
-  effects: [],
 });
 
 export const selectedCities = atom<Array<City>>({

--- a/web/src/data/recoil.ts
+++ b/web/src/data/recoil.ts
@@ -69,6 +69,7 @@ export const selectedCity = atom({
 export const selectedCities = atom<Array<City>>({
   key: "selectedCities",
   default: [],
+  effects: [localStorageEffect()]
 });
 
 export const isUpdatingCities = atom({

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -169,6 +169,7 @@ const SelectCityCheckbox = (props: {
 };
 
 const StatsWrapper = () => {
+  const isFirstRender = React.useRef(true);
   const [selectedCities] = useRecoilState(selectedCitiesFromRecoil);
   const [isUpdating] = useRecoilState(isUpdatingCities);
   const [lastSelectedCityId, setLastSelectedCityId] =
@@ -176,12 +177,6 @@ const StatsWrapper = () => {
   const [totalSelectableCities, setTotalSelectableCities] =
     React.useState(selectedCities);
   const { updateCityList } = useUpdateCityList();
-
-  React.useEffect(() => {
-    // This function will only be called once, when the component is first rendered
-    updateCityList();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // empty dependency array means the effect runs only once
 
   React.useEffect(() => {
     const selectableCityIds = SELECTABLE_CITIES_DATA.map((c) => c.id);
@@ -196,6 +191,11 @@ const StatsWrapper = () => {
       setLastSelectedCityId(selectedCities[0].id);
     }
   }, [selectedCities, lastSelectedCityId, setLastSelectedCityId]);
+
+  if (isFirstRender.current) {
+    updateCityList();
+    isFirstRender.current = false;
+  }
 
   return (
     <>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -175,6 +175,13 @@ const StatsWrapper = () => {
     useRecoilState(selectedCity);
   const [totalSelectableCities, setTotalSelectableCities] =
     React.useState(selectedCities);
+  const { updateCityList } = useUpdateCityList();
+
+  React.useEffect(() => {
+    // This function will only be called once, when the component is first rendered
+    updateCityList();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // empty dependency array means the effect runs only once
 
   React.useEffect(() => {
     const selectableCityIds = selectableCitiesData.map((c) => c.id);
@@ -220,7 +227,7 @@ const StatsWrapper = () => {
   );
 };
 
-export const NotificationsMap = () => {
+export const Dashboard = () => {
   const { connected, initialized } = useConnectionState();
   const enabled = useRecoilValue(simulatorEnabled);
   useSimulationMonitor(enabled && connected && initialized);

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -21,7 +21,7 @@ import { IngestChart, useIngestChartData } from "@/components/IngestChart";
 import { PixiMap } from "@/components/PixiMap";
 import { SetupDatabaseButton } from "@/components/SetupDatabaseButton";
 import { Stats } from "@/components/Stats";
-import { selectableCitiesData } from "@/data/constants";
+import { SELECTABLE_CITIES_DATA } from "@/data/constants";
 import { useUpdateCityList } from "@/data/models/useUpdateCityList";
 import { City } from "@/data/queries";
 import {
@@ -94,7 +94,7 @@ const SelectCityCheckbox = (props: {
   const getNewSelectedCityAfterDeletion = (city: City): number => {
     const cityIndex = selectedCities.findIndex((c) => c.id === city.id);
     if (cityIndex === 0 && selectedCities.length > 1) {
-      return selectableCitiesData[1].id;
+      return SELECTABLE_CITIES_DATA[1].id;
     }
     return -1;
   };
@@ -180,16 +180,16 @@ const StatsWrapper = () => {
   React.useEffect(() => {
     // This function will only be called once, when the component is first rendered
     updateCityList();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // empty dependency array means the effect runs only once
 
   React.useEffect(() => {
-    const selectableCityIds = selectableCitiesData.map((c) => c.id);
+    const selectableCityIds = SELECTABLE_CITIES_DATA.map((c) => c.id);
     const unknownSelectedCities = selectedCities.filter(
       (c) => !selectableCityIds.includes(c.id)
     );
     setTotalSelectableCities([
-      ...selectableCitiesData,
+      ...SELECTABLE_CITIES_DATA,
       ...unknownSelectedCities,
     ]);
     if (lastSelectedCityId === -1 && selectedCities.length > 0) {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -169,14 +169,13 @@ const SelectCityCheckbox = (props: {
 };
 
 const StatsWrapper = () => {
-  const isFirstRender = React.useRef(true);
   const [selectedCities] = useRecoilState(selectedCitiesFromRecoil);
   const [isUpdating] = useRecoilState(isUpdatingCities);
   const [lastSelectedCityId, setLastSelectedCityId] =
     useRecoilState(selectedCity);
   const [totalSelectableCities, setTotalSelectableCities] =
     React.useState(selectedCities);
-  const { updateCityList } = useUpdateCityList();
+  const mutableCityListHook = React.useRef(useUpdateCityList());
 
   React.useEffect(() => {
     const selectableCityIds = SELECTABLE_CITIES_DATA.map((c) => c.id);
@@ -192,10 +191,9 @@ const StatsWrapper = () => {
     }
   }, [selectedCities, lastSelectedCityId, setLastSelectedCityId]);
 
-  if (isFirstRender.current) {
-    updateCityList();
-    isFirstRender.current = false;
-  }
+  React.useEffect(() => {
+      mutableCityListHook.current.updateCityList();
+  }, [mutableCityListHook.current.updateCityList]);
 
   return (
     <>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -175,7 +175,6 @@ const StatsWrapper = () => {
     useRecoilState(selectedCity);
   const [totalSelectableCities, setTotalSelectableCities] =
     React.useState(selectedCities);
-  const mutableCityListHook = React.useRef(useUpdateCityList());
 
   React.useEffect(() => {
     const selectableCityIds = SELECTABLE_CITIES_DATA.map((c) => c.id);
@@ -190,10 +189,6 @@ const StatsWrapper = () => {
       setLastSelectedCityId(selectedCities[0].id);
     }
   }, [selectedCities, lastSelectedCityId, setLastSelectedCityId]);
-
-  React.useEffect(() => {
-      mutableCityListHook.current.updateCityList();
-  }, [mutableCityListHook.current.updateCityList]);
 
   return (
     <>

--- a/web/src/view/hooks/hooks.ts
+++ b/web/src/view/hooks/hooks.ts
@@ -6,7 +6,6 @@ import useSWR, { useSWRConfig } from "swr";
 import { SQLError } from "@/data/client";
 import { isConnected, resetSchema, schemaObjects } from "@/data/queries";
 import {
-  connectedToDB,
   connectionConfig,
   portalConnectionConfig,
   resettingSchema,
@@ -43,17 +42,10 @@ export const useConnectionState = () => {
   // we are using ES6 spread syntax to remove database from config
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { ...config } = useRecoilValue(connectionConfig);
-  const [ connectedFromRecoil, setConnectedInRecoil] = useRecoilState(connectedToDB);
   const connected = useSWR(["isConnected", config], () => isConnected(config));
   const schemaObjs = useSchemaObjects(!connected.data);
   const portalConfig = useRecoilValue(portalConnectionConfig);
   let connectionType;
-
-  React.useEffect(() => {
-    if (connected.data !== undefined) {
-      setConnectedInRecoil(!!connected.data);
-    }
-  }, [connected, setConnectedInRecoil]);
 
   if (portalConfig) {
     connectionType = "portal";
@@ -62,7 +54,8 @@ export const useConnectionState = () => {
   }
 
   return {
-    connected: connectedFromRecoil,
+    connected: !!connected.data,
+    isValidatingConnection: connected.isValidating,
     initialized:
       !!connected.data && Object.values(schemaObjs.data || []).every(Boolean),
     reset: () => {

--- a/web/src/view/hooks/hooks.ts
+++ b/web/src/view/hooks/hooks.ts
@@ -45,8 +45,8 @@ export const useConnectionState = () => {
   const connected = useSWR(["isConnected", config], () => isConnected(config));
   const schemaObjs = useSchemaObjects(!connected.data);
   const portalConfig = useRecoilValue(portalConnectionConfig);
-  let connectionType;
 
+  let connectionType;
   if (portalConfig) {
     connectionType = "portal";
   } else if (connected.data) {

--- a/web/src/view/hooks/hooks.ts
+++ b/web/src/view/hooks/hooks.ts
@@ -6,6 +6,7 @@ import useSWR, { useSWRConfig } from "swr";
 import { SQLError } from "@/data/client";
 import { isConnected, resetSchema, schemaObjects } from "@/data/queries";
 import {
+  connectedToDB,
   connectionConfig,
   portalConnectionConfig,
   resettingSchema,
@@ -42,11 +43,17 @@ export const useConnectionState = () => {
   // we are using ES6 spread syntax to remove database from config
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { ...config } = useRecoilValue(connectionConfig);
+  const [ connectedFromRecoil, setConnectedInRecoil] = useRecoilState(connectedToDB);
   const connected = useSWR(["isConnected", config], () => isConnected(config));
   const schemaObjs = useSchemaObjects(!connected.data);
   const portalConfig = useRecoilValue(portalConnectionConfig);
-
   let connectionType;
+
+  React.useEffect(() => {
+    if (connected.data !== undefined) {
+      setConnectedInRecoil(!!connected.data);
+    }
+  }, [connected, setConnectedInRecoil]);
 
   if (portalConfig) {
     connectionType = "portal";
@@ -55,7 +62,7 @@ export const useConnectionState = () => {
   }
 
   return {
-    connected: !!connected.data,
+    connected: connectedFromRecoil,
     initialized:
       !!connected.data && Object.values(schemaObjs.data || []).every(Boolean),
     reset: () => {


### PR DESCRIPTION
## Summary

Fixes
1. Avoid state loss on reload. No more homepage popups on reload and state loss of various state variables due to disconnect from DB during reload.
2. Store locally selected city list to avoid loss of data due to recoil reset after reload

## Test Plan

1. Pull the MR and from the terminal go to the web folder using the command `cd ./web`
2. In case you are using the RTDM project for the first time install dependencies using `yarn install`
3. Start the service using `yarn dev` and visit `http://localhost:3000`

You will see the changes implemented
https://user-images.githubusercontent.com/20814995/228824600-41e2a0de-ddd1-402b-881e-bc71378810f2.mp4

## Changes

- Avoid state loss on reload. No more homepage popups on reload and state loss of various state variables due to disconnect from DB during reload.
- Store locally selected city list to avoid loss of data due to recoil reset after reload

## Subscribers

@mivasconcelos  @TitoGrine w