### PR TITLE
Bug fix: Fix $ typo shown in table count on configure page offers section

### DIFF
--- a/web/src/pages/Configure.tsx
+++ b/web/src/pages/Configure.tsx
@@ -628,7 +628,7 @@ const OffersSection = ({
       <Text>
         <br />
         The map to your right displays a polygon representing each offer's
-        activation zone. Currently, There are ${tableCounts.data?.offers ||
+        activation zone. Currently, there are {tableCounts.data?.offers ||
           0}{" "}
         offers in the database.
       </Text>

--- a/web/src/pages/Configure.tsx
+++ b/web/src/pages/Configure.tsx
@@ -661,7 +661,7 @@ const OffersSection = ({
             list of segments and notification content. As subscribers travel,
             they are matched with offers based on their location and segments.
             If multiple offers match to a subscriber, the highest bid price is
-            selected. There are 200 simulated offers in the database.
+            selected.
           </Text>
           {loadOffersButton}
           {mapInfoContent}


### PR DESCRIPTION
## Summary
There was a type On the configuration page in the notification section where it shows table counts. it was showing count as $ ex- $1800 rows.

The MR aims to fix this type by removing the $ symbol in front

## Test Plan

1. Pull the MR and from the terminal go to the web folder using the command `cd ./web`
2. In case you are using the RTDM project for the first time install dependencies using `yarn install`
3. Start the service using `yarn dev` and visit `http://localhost:3000`
4. Go to the configuration offer section and try triggering the offer.
5. You will see a statement showing the offers loaded in the database and others that should be no $


## Subscribers
