### PR TITLE
Change Map provider

### DIFF
--- a/web/src/components/PixiMap.tsx
+++ b/web/src/components/PixiMap.tsx
@@ -6,7 +6,6 @@ import {
   Center,
   Divider,
   Flex,
-  Link,
   Stack,
   Text,
   Tooltip,
@@ -15,6 +14,7 @@ import {
   useConst,
 } from "@chakra-ui/react";
 import { Bounds, Map, PigeonProps, Point } from "pigeon-maps";
+import { osm } from "pigeon-maps/providers";
 import * as PIXI from "pixi.js";
 import * as React from "react";
 import Select, { GroupBase, StylesConfig } from "react-select";
@@ -28,22 +28,6 @@ import {
   selectedCity,
 } from "@/data/recoil";
 import { useConnectionState } from "@/view/hooks/hooks";
-
-const stamenProvider =
-  (flavor: "toner" | "toner-lite") =>
-  (x: number, y: number, z: number, dpr = 1) =>
-    `https://stamen-tiles.a.ssl.fastly.net/${flavor}/${z}/${x}/${y}${
-      dpr >= 2 ? "@2x" : ""
-    }.png`;
-
-const stamenAttribution = (
-  <>
-    Map tiles by <Link href="http://stamen.com">Stamen Design</Link>, under{" "}
-    <Link href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</Link>.
-    Data by <Link href="http://openstreetmap.org">OpenStreetMap</Link>, under{" "}
-    <Link href="http://www.openstreetmap.org/copyright">ODbL</Link>.
-  </>
-);
 
 export const DEFAULT_CENTER: [number, number] = [
   DEFAULT_CITY.lonlat[1],
@@ -371,8 +355,7 @@ export const PixiMap = <T,>({
       <Box width="100%" overflow="hidden" height={height} {...rest}>
         <Map
           dprs={[1, 2]}
-          provider={stamenProvider("toner-lite")}
-          attribution={stamenAttribution}
+          provider={osm}
           maxZoom={18}
           minZoom={5}
           onBoundsChanged={handleBoundsChange}

--- a/web/src/data/recoil.ts
+++ b/web/src/data/recoil.ts
@@ -62,17 +62,17 @@ export const selectedCity = atom({
 
 export const defaultSelectedCities = selector<Array<City>>({
   key: "defaultSelectedCities",
-  get: async ({get}) => {
+  get: async ({ get }) => {
     const config = get(connectionConfig);
     let selectedCities: Array<City> = [];
     try {
       selectedCities = await getCities(config);
     } catch (error) {
       selectedCities = [];
-      console.log('Failed to fetch selected cities details from the Database.');
+      console.log("Failed to fetch selected cities details from the Database.");
     }
     return selectedCities;
-  }
+  },
 });
 
 export const selectedCities = atom<Array<City>>({


### PR DESCRIPTION
The map provider we were using is now paid (more info at https://maps.stamen.com/stadia-partnership/), so we have to update our provider as described here https://pigeon-maps.js.org/docs/tile-provider/

 I went with `osm` because it was the one that, in my opinion, looked better in the app.

[Untitled_ Oct 19, 2023 3_29 PM.webm](https://github.com/singlestore-labs/demo-realtime-digital-marketing/assets/72758386/51ea8dac-d509-4a69-9833-179e88160ab0)

(the video looks like bad quality, but it was fine)