### PR TITLE
fix: add CNAME file to enable custom domain deployment

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -56,6 +56,10 @@ jobs:
         run: yarn run vite build
         working-directory: web
 
+      - name: Add CNAME for custom domain
+        if: github.ref == 'refs/heads/main'
+        run: echo "digital-marketing.labs.singlestore.com" > web/dist/CNAME
+
       - name: Deploy
         if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v2


### PR DESCRIPTION
Add build step to create CNAME file with digital-marketing.labs.singlestore.com before deployment to gh-pages. This fixes the 404 error on the custom domain.

Without the CNAME file, GitHub Pages only serves the site at the default github.io URL. The CNAME file tells GitHub Pages to also serve at the custom domain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the deploy workflow on main; no application or auth logic is touched.
> 
> **Overview**
> Fixes GitHub Pages serving only on the default `github.io` URL by writing a **CNAME** into the build output before deploy.
> 
> On pushes to **main**, after `vite build`, CI adds `web/dist/CNAME` with `digital-marketing.labs.singlestore.com`, then publishes `./web/dist` to **gh-pages** as before. That tells GitHub Pages to serve the site on the custom domain and addresses the custom-domain **404**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a18604deb415caf20cd1ebe507878b183b5a2ba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->