### PR TITLE
Increase purchase and request probabilities for better demo metrics

### DIFF
--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -26,8 +26,8 @@ var (
 	numPartitions  = flag.Int("partitions", 1, "number of partitions")
 	numSubscribers = flag.Int("subscribers", 100_000, "number of subscribers")
 
-	purchaseProb = flag.Float64("purchase-prob", 0.05, "purchase probability")
-	requestProb  = flag.Float64("request-prob", 0.3, "request probability")
+	purchaseProb = flag.Float64("purchase-prob", 0.15, "purchase probability")
+	requestProb  = flag.Float64("request-prob", 0.4, "request probability")
 
 	minSpeed = flag.Float64("min-speed", 0.001, "minimum speed")
 	maxSpeed = flag.Float64("max-speed", 0.01, "maximum speed")


### PR DESCRIPTION
- Purchase probability: 5% → 15% (3x increase)
- Request probability: 30% → 40%
- Results in more conversions across more companies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI default-only change with no logic or data-path modifications; behavior is unchanged when flags are set explicitly.
> 
> **Overview**
> Raises the **default** simulation rates in `cmd/simulator` so demo runs show more activity without passing flags.
> 
> **`-purchase-prob`** default goes from **5%** to **15%**; **`-request-prob`** from **30%** to **40%**. Those values still populate `gen.State` and drive the same per-iteration request/purchase rolls in `gen/update.go`—only the out-of-the-box traffic mix is denser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f29fb2a71fa558434d8e07fe78710a4403f2630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->