### PR TITLE
Akwong/disable plancache check

### DIFF
--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -26,8 +26,8 @@ var (
 	numPartitions  = flag.Int("partitions", 1, "number of partitions")
 	numSubscribers = flag.Int("subscribers", 100_000, "number of subscribers")
 
-	purchaseProb = flag.Float64("purchase-prob", 0.05, "purchase probability")
-	requestProb  = flag.Float64("request-prob", 0.3, "request probability")
+	purchaseProb = flag.Float64("purchase-prob", 0.15, "purchase probability")
+	requestProb  = flag.Float64("request-prob", 0.4, "request probability")
 
 	minSpeed = flag.Float64("min-speed", 0.001, "minimum speed")
 	maxSpeed = flag.Float64("max-speed", 0.01, "maximum speed")

--- a/web/src/data/queries.ts
+++ b/web/src/data/queries.ts
@@ -361,35 +361,9 @@ export const ensurePipelinesAreRunning = async (config: ConnectionConfig) => {
 
 // returns true if any plans were dropped
 export const checkPlans = async (config: ConnectionConfig) => {
-  const badPlans = await Query<{ planId: string }>(
-    config,
-    `
-      SELECT plan_id AS planId
-      FROM information_schema.plancache
-      WHERE
-        plan_warnings LIKE "%empty tables%"
-    `
-  );
-
-  // Only attempt to drop plans if there are any to drop
-  if (badPlans.length > 0) {
-    // Drop each plan individually, ignoring "plan missing" errors
-    // This prevents one failed drop from blocking others
-    await Promise.all(
-      badPlans.map(async ({ planId }) => {
-        try {
-          await Exec(config, `DROP ${planId} FROM PLANCACHE`);
-        } catch (e) {
-          // Silently ignore if plan was already dropped
-          if (!(e instanceof SQLError && e.isPlanMissing())) {
-            throw e;
-          }
-        }
-      })
-    );
-  }
-
-  return badPlans.length > 0;
+  // Disabled: plancache checking was causing persistent error dialogs
+  // The database warms up naturally without manual plan drops
+  return false;
 };
 
 export const estimatedRowCount = <TableName extends string>(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes remove optional plan-cache cleanup and adjust simulator CLI defaults only; no auth, persistence, or production query-path changes.
> 
> **Overview**
> **Disables automatic plancache maintenance** in the web app: `checkPlans` no longer queries `information_schema.plancache` for plans with “empty tables” warnings or runs `DROP … FROM PLANCACHE`. It always returns `false`, so Configure and `useSimulationMonitor` will not enter the “warming up” path driven by dropped plans (intended to stop recurring error dialogs; comment notes the DB warms up on its own).
> 
> **Raises subscriber-simulator defaults** for `purchase-prob` (0.05 → 0.15) and `request-prob` (0.3 → 0.4), increasing simulated purchase and request activity out of the box.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ccb6c50df6abf6659bfe9b973f94208d992d270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->