### PR TITLE
Skip Docker build workflow on forks

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,10 +4,15 @@ on:
   push:
     branches:
       - "main"
+    # Skip if this is a fork (not the upstream singlestore-labs repo)
+    # Forks don't have permission to push to singlestore-labs GHCR
+  workflow_dispatch: # Allow manual triggers
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+    # Only run on the upstream repo, not forks
+    if: github.repository == 'singlestore-labs/demo-realtime-digital-marketing'
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
The build-docker-image workflow was failing on forks because it tries to push to ghcr.io/singlestore-labs/... which requires organization write permissions that forks don't have.

Added condition to only run the workflow on the upstream repository:
  if: github.repository == 'singlestore-labs/demo-realtime-digital-marketing'

This prevents the 403 error:
  denied: installation not allowed to Write organization package

Forks can still run the workflow manually via workflow_dispatch if needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change; upstream image publishing behavior on main is unchanged.
> 
> **Overview**
> Stops the **build-docker-image** workflow from running on forked copies of the repo, where pushes to `ghcr.io/singlestore-labs/...` fail with organization package write permission errors.
> 
> Adds a job-level `if: github.repository == 'singlestore-labs/demo-realtime-digital-marketing'` so only the upstream repository builds and publishes on `main` pushes. **`workflow_dispatch`** is added so the workflow can still be triggered manually when needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5f7e0c1ec610d46142763683162b69b006c92cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->