### PR TITLE
Akwong/fix docker workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,10 +4,15 @@ on:
   push:
     branches:
       - "main"
+    # Skip if this is a fork (not the upstream singlestore-labs repo)
+    # Forks don't have permission to push to singlestore-labs GHCR
+  workflow_dispatch: # Allow manual triggers
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+    # Only run on the upstream repo, not forks
+    if: github.repository == 'singlestore-labs/demo-realtime-digital-marketing'
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -14,6 +14,9 @@ jobs:
     # Only run on the upstream repo, not forks
     if: github.repository == 'singlestore-labs/demo-realtime-digital-marketing'
     steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
@@ -27,8 +30,19 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Determine Docker tags
+        id: tags
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "tags=ghcr.io/singlestore-labs/demo-realtime-digital-marketing:latest" >> $GITHUB_OUTPUT
+          else
+            # For non-main branches, use branch name as tag
+            BRANCH_NAME=$(echo "${{ github.ref }}" | sed 's/refs\/heads\///' | sed 's/\//-/g')
+            echo "tags=ghcr.io/singlestore-labs/demo-realtime-digital-marketing:$BRANCH_NAME" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ghcr.io/singlestore-labs/demo-realtime-digital-marketing:latest
+          tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -25,6 +25,8 @@ jobs:
 
   deploy-web:
     runs-on: ubuntu-latest
+    # Only deploy from upstream repo, not forks
+    if: github.repository == 'singlestore-labs/demo-realtime-digital-marketing'
     steps:
       - name: Checkout source
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions configuration; they reduce accidental deploy/push from forks and do not alter application runtime code.
> 
> **Overview**
> **CI/CD workflows** are tightened so forked repos no longer run jobs that push to SingleStore’s GHCR or deploy the web app.
> 
> The **Docker image workflow** now checks out the repo before building, can be started manually via `workflow_dispatch`, and only runs when `github.repository` is the upstream demo repo. Image tags are computed in a step: **`main` → `latest`**, other refs (e.g. manual runs) → a sanitized branch name tag instead of always pushing `latest`.
> 
> The **on-push workflow** applies the same upstream-only guard to the **`deploy-web`** job so forks still run Go tests but skip GitHub Pages deployment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b54d9c098a698d79db4e9da97f51188a335caa93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->