### PR TITLE
Fix queryAnalyst call signature for Docker build

### DIFF
--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -144,6 +144,7 @@ export const AnalystChat: React.FC = () => {
         },
         apiKey,
         endpointUrl,
+        undefined, // callbacks - not used yet
         abortControllerRef.current?.signal
       );
 


### PR DESCRIPTION
- Add undefined for callbacks parameter (4th param)
- AbortSignal is now 5th parameter after callbacks
- Resolves TypeScript error: Type 'AbortSignal' has no properties in common with type 'StreamCallback'

This fixes the Docker build failure after merging PR #61

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single call-site argument fix with no behavior change beyond correct typing; abort and request flow stay the same.
> 
> **Overview**
> Fixes a **TypeScript compile failure** in the Docker build by aligning the `queryAnalyst` call in `AnalystChat` with the client signature from PR #61.
> 
> The call now passes **`undefined` as the 4th argument** (optional stream callbacks, not used in chat yet) and keeps **`AbortSignal` as the 5th argument**, so the signal is no longer mistaken for `StreamCallback`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 288bddd77376673607d11513ca3fc393a01f43f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->