### PR TITLE
Akwong/re add chart rendering

### DIFF
--- a/ANALYST_FIXES_NEEDED.md
+++ b/ANALYST_FIXES_NEEDED.md
@@ -1,0 +1,129 @@
+# Aura Analyst Fixes Needed
+
+## Issue 1: Multiple Previous Answers Appearing in Chat
+
+**Problem:**
+The Analyst API returns multiple results in the `results` array, and the UI displays ALL of them. This causes old conversation history to appear as separate messages in the chat.
+
+Example API response:
+```json
+{
+  "results": [
+    {"text": "There are **3 r's** in strawberry..."},  // Current answer
+    {"text": "There are **2 r's** in strawbery..."}   // Previous answer
+  ]
+}
+```
+
+**Root Cause:**
+In `AnalystChat.tsx` lines 156-164, the code loops through ALL results:
+```typescript
+for (const result of response.results) {
+  // Adds EVERY result as a separate message
+  setMessages((prev) => [...prev, assistantMessage]);
+}
+```
+
+**Fix Applied:**
+Changed to only show the first/most recent result:
+```typescript
+// Only show the first result to avoid duplicates from conversation history
+const result = response.results[0];
+const formatted = formatAnalystResult(result);
+setMessages((prev) => [...prev, assistantMessage]);
+```
+
+**File:** `web/src/components/AnalystChat.tsx`
+
+---
+
+## Issue 2: Chat Review Shows Duplicate Questions
+
+**Problem:**
+The Chat Review in SingleStore Portal shows the same question multiple times (e.g., "how many r's in strawberry" appears 10+ times).
+
+**Likely Root Cause:**
+This is happening on the **Analyst backend side**, not in the React app. Possible causes:
+1. The app is sending multiple requests for the same question (retries?)
+2. The session ID isn't being sent correctly, causing each request to create a new conversation
+3. The Analyst backend is logging queries multiple times
+
+**To investigate:**
+1. Check network tab - are multiple API calls being made for one user question?
+2. Check if `session_id` is being sent consistently in requests
+3. Check if the Analyst backend has a bug in how it logs queries to Chat Review
+
+**Current session_id handling:**
+```typescript
+const [sessionId] = React.useState<string>(() => crypto.randomUUID());
+```
+
+This creates a session ID once per component mount. If the component unmounts/remounts, a new session is created.
+
+---
+
+## Issue 3: API Key Obfuscation Needed
+
+**Problem:**
+The API key is displayed in plain text in the Configure page input field. Should be obfuscated with dots (•••) when not being edited.
+
+**Implementation Plan:**
+
+### Option A: Input type="password" (Simplest)
+```typescript
+<Input
+  type={isEditing ? "text" : "password"}
+  placeholder="eyJhbGciOiJFUzUxMiIsImtpZCI..."
+  value={localApiKey}
+  onFocus={() => setIsEditing(true)}
+  onBlur={() => setIsEditing(false)}
+/>
+```
+
+### Option B: InputGroup with show/hide button (Better UX)
+```typescript
+<InputGroup>
+  <Input
+    type={showApiKey ? "text" : "password"}
+    value={localApiKey}
+    onChange={(e) => setLocalApiKey(e.target.value)}
+  />
+  <InputRightElement>
+    <IconButton
+      icon={showApiKey ? <ViewOffIcon /> : <ViewIcon />}
+      onClick={() => setShowApiKey(!showApiKey)}
+    />
+  </InputRightElement>
+</InputGroup>
+```
+
+### Option C: Custom masking (Most control)
+```typescript
+const maskApiKey = (key: string) => {
+  if (!key || key.length < 8) return key;
+  return `${key.slice(0, 4)}${'•'.repeat(key.length - 8)}${key.slice(-4)}`;
+};
+
+// Display: eyJh••••••••••kpZCI
+```
+
+**Recommended:** Option B (InputGroup with toggle) - gives users control
+
+**File to modify:** `web/src/pages/Configure.tsx` (AnalystConfigSection component)
+
+---
+
+## Fix Status
+
+- [x] Issue 1: Multiple results bug - **FIXED** in AnalystChat.tsx (not committed)
+- [ ] Issue 2: Chat Review duplicates - **NEEDS INVESTIGATION** (likely backend issue)
+- [ ] Issue 3: API key obfuscation - **NOT IMPLEMENTED YET** (waiting for direction)
+
+---
+
+## Notes
+
+- The current branch (`akwong/fix-analyst-issues`) has Issue 1 fixed
+- Issue 3 requires changes to the Configure.tsx file with the Analyst UI config
+- That config was added in PR #58 (commit c20cf46) which is already merged to main
+- Need to rebase this branch on latest main to have both fixes together

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -150,6 +150,7 @@ export const AnalystChat: React.FC = () => {
         },
         apiKey,
         endpointUrl,
+        undefined, // callbacks - not used yet
         abortControllerRef.current?.signal
       );
 

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -49,7 +49,7 @@ interface Message {
   role: "user" | "assistant";
   content: string;
   result?: AnalystQueryResult;
-  processingSteps?: Array<{ type: "status" | "query"; content: string }>;
+  processingSteps?: Array<{ type: "status" | "query" | "reasoning"; content: string }>;
 }
 
 export const AnalystChat: React.FC = () => {
@@ -152,8 +152,8 @@ export const AnalystChat: React.FC = () => {
     // Create abort controller for this request
     abortControllerRef.current = new AbortController();
 
-    // Track processing steps (queries executed)
-    const processingSteps: Array<{ type: "status" | "query"; content: string }> = [];
+    // Track processing steps (reasoning and queries executed)
+    const processingSteps: Array<{ type: "status" | "query" | "reasoning"; content: string }> = [];
 
     try {
       const response = await queryAnalyst(
@@ -165,6 +165,9 @@ export const AnalystChat: React.FC = () => {
         apiKey,
         endpointUrl,
         {
+          onReasoning: (reasoning: string) => {
+            processingSteps.push({ type: "reasoning", content: reasoning });
+          },
           onQuery: (query: string) => {
             processingSteps.push({ type: "query", content: query });
           },
@@ -592,32 +595,79 @@ export const AnalystChat: React.FC = () => {
                   )}
                   {msg.processingSteps && msg.processingSteps.length > 0 && (
                     <Accordion allowToggle mt={2}>
-                      <AccordionItem border="none">
-                        <AccordionButton px={0} _hover={{ bg: "transparent" }}>
-                          <Box flex="1" textAlign="left" fontSize="xs" fontWeight="medium">
-                            View Queries ({msg.processingSteps.filter(s => s.type === "query").length})
-                          </Box>
-                          <AccordionIcon />
-                        </AccordionButton>
-                        <AccordionPanel px={0} pb={2}>
-                          <VStack align="stretch" spacing={2}>
-                            {msg.processingSteps
-                              .filter(step => step.type === "query")
-                              .map((step, stepIdx) => (
-                                <Code
-                                  key={stepIdx}
-                                  p={2}
-                                  borderRadius="md"
-                                  fontSize="xs"
-                                  whiteSpace="pre-wrap"
-                                  display="block"
-                                >
-                                  {step.content}
-                                </Code>
-                              ))}
-                          </VStack>
-                        </AccordionPanel>
-                      </AccordionItem>
+                      {msg.processingSteps.some(s => s.type === "reasoning") && (
+                        <AccordionItem border="none">
+                          <AccordionButton px={0} _hover={{ bg: "transparent" }}>
+                            <Box flex="1" textAlign="left" fontSize="xs" fontWeight="medium">
+                              💭 View Reasoning
+                            </Box>
+                            <AccordionIcon />
+                          </AccordionButton>
+                          <AccordionPanel px={0} pb={2}>
+                            <VStack align="stretch" spacing={2}>
+                              {msg.processingSteps
+                                .filter(step => step.type === "reasoning")
+                                .map((step, stepIdx) => (
+                                  <Box
+                                    key={stepIdx}
+                                    p={3}
+                                    borderRadius="md"
+                                    fontSize="xs"
+                                    whiteSpace="pre-wrap"
+                                    bg={useColorModeValue("gray.50", "gray.700")}
+                                    borderLeft="3px solid"
+                                    borderColor="purple.400"
+                                  >
+                                    <ReactMarkdown
+                                      components={{
+                                        p: ({ children }) => <Text mb={1} fontSize="xs">{children}</Text>,
+                                        code: ({ inline, children }) =>
+                                          inline ? (
+                                            <Code fontSize="xs">{children}</Code>
+                                          ) : (
+                                            <Code display="block" p={2} fontSize="xs" whiteSpace="pre-wrap">
+                                              {children}
+                                            </Code>
+                                          ),
+                                      }}
+                                    >
+                                      {step.content}
+                                    </ReactMarkdown>
+                                  </Box>
+                                ))}
+                            </VStack>
+                          </AccordionPanel>
+                        </AccordionItem>
+                      )}
+                      {msg.processingSteps.some(s => s.type === "query") && (
+                        <AccordionItem border="none">
+                          <AccordionButton px={0} _hover={{ bg: "transparent" }}>
+                            <Box flex="1" textAlign="left" fontSize="xs" fontWeight="medium">
+                              📊 View Queries ({msg.processingSteps.filter(s => s.type === "query").length})
+                            </Box>
+                            <AccordionIcon />
+                          </AccordionButton>
+                          <AccordionPanel px={0} pb={2}>
+                            <VStack align="stretch" spacing={2}>
+                              {msg.processingSteps
+                                .filter(step => step.type === "query")
+                                .map((step, stepIdx) => (
+                                  <Code
+                                    key={stepIdx}
+                                    p={2}
+                                    borderRadius="md"
+                                    fontSize="xs"
+                                    whiteSpace="pre-wrap"
+                                    display="block"
+                                    colorScheme="purple"
+                                  >
+                                    {step.content}
+                                  </Code>
+                                ))}
+                            </VStack>
+                          </AccordionPanel>
+                        </AccordionItem>
+                      )}
                     </Accordion>
                   )}
                   {msg.result && renderCharts(msg.result)}

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -173,7 +173,6 @@ export const AnalystChat: React.FC = () => {
             processingSteps.push({ type: "query", content: query });
           },
         },
-        undefined, // callbacks - not used yet
         abortControllerRef.current?.signal
       );
 
@@ -682,9 +681,6 @@ export const AnalystChat: React.FC = () => {
                       )}
                     </Accordion>
                   )}
-                  <Text fontSize="sm" whiteSpace="pre-wrap">
-                    {msg.content}
-                  </Text>
                   {msg.result && renderCharts(msg.result)}
                   {msg.result && renderTables(msg.result)}
                   {msg.result && renderData(msg.result)}

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -359,7 +359,7 @@ export const AnalystChat: React.FC = () => {
             paper_bgcolor: chartIsDark ? "#2D3748" : "white",
             plot_bgcolor: chartIsDark ? "#2D3748" : "#E5ECF6",
             font: {
-              ...chart.layout.font,
+              ...(chart.layout.font || {}),
               color: chartIsDark ? "white" : "#2a3f5f",
             },
             autosize: true,

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -63,6 +63,9 @@ export const AnalystChat: React.FC = () => {
   const borderColor = useColorModeValue("gray.200", "gray.600");
   const userBgColor = useColorModeValue("#820DDF", "#9333EA");
   const assistantBgColor = useColorModeValue("gray.100", "gray.700");
+  const chartBgColor = useColorModeValue("white", "gray.700");
+  const chartTextColor = useColorModeValue("black", "white");
+  const chartIsDark = useColorModeValue(false, true);
 
   React.useEffect(() => {
     return () => {
@@ -295,11 +298,6 @@ export const AnalystChat: React.FC = () => {
   const renderCharts = (result: AnalystQueryResult) => {
     if (!result.charts || result.charts.length === 0) return null;
 
-    // Call hooks at the top level
-    const isDark = useColorModeValue(false, true);
-    const bgColor = useColorModeValue("white", "gray.700");
-    const textColor = useColorModeValue("black", "white");
-
     return (
       <>
         {result.charts.map((chart, chartIdx) => {
@@ -334,11 +332,11 @@ export const AnalystChat: React.FC = () => {
 
           const plotLayout = {
             ...layoutCopy,
-            paper_bgcolor: isDark ? "#2D3748" : "white",
-            plot_bgcolor: isDark ? "#2D3748" : "#E5ECF6",
+            paper_bgcolor: chartIsDark ? "#2D3748" : "white",
+            plot_bgcolor: chartIsDark ? "#2D3748" : "#E5ECF6",
             font: {
               ...layoutCopy.font,
-              color: isDark ? "white" : "#2a3f5f",
+              color: chartIsDark ? "white" : "#2a3f5f",
             },
             autosize: true,
             margin: { l: 50, r: 50, b: 50, t: 50, pad: 4 },
@@ -349,12 +347,12 @@ export const AnalystChat: React.FC = () => {
               key={`chart-${chartIdx}-${chart.title}`}
               mt={3}
               width="100%"
-              bg={bgColor}
+              bg={chartBgColor}
               p={2}
               borderRadius="md"
             >
               {chart.title && (
-                <Text fontWeight="bold" mb={2} fontSize="sm" color={textColor}>
+                <Text fontWeight="bold" mb={2} fontSize="sm" color={chartTextColor}>
                   {chart.title}
                 </Text>
               )}

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -353,7 +353,9 @@ export const AnalystChat: React.FC = () => {
           x: Array.isArray(trace.x) ? trace.x.map(maybeParseNumber) : trace.x,
         }));
 
-        const layoutCopy = JSON.parse(JSON.stringify(chartCopy.figure.layout));
+        const layoutCopy = chartCopy.figure.layout
+          ? JSON.parse(JSON.stringify(chartCopy.figure.layout))
+          : {};
 
         return {
           title: chart.title,

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -20,11 +20,18 @@ import {
   MenuButton,
   MenuList,
   MenuItem,
+  Code,
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
 } from "@chakra-ui/react";
 import { CloseIcon, ChatIcon, ChevronDownIcon } from "@chakra-ui/icons";
 import * as React from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { Link as RouterLink } from "react-router-dom";
+import ReactMarkdown from "react-markdown";
 import Plotly from "plotly.js-dist-min";
 import createPlotlyComponent from "react-plotly.js/factory";
 import {
@@ -42,6 +49,7 @@ interface Message {
   role: "user" | "assistant";
   content: string;
   result?: AnalystQueryResult;
+  processingSteps?: Array<{ type: "status" | "query"; content: string }>;
 }
 
 export const AnalystChat: React.FC = () => {
@@ -144,6 +152,9 @@ export const AnalystChat: React.FC = () => {
     // Create abort controller for this request
     abortControllerRef.current = new AbortController();
 
+    // Track processing steps (queries executed)
+    const processingSteps: Array<{ type: "status" | "query"; content: string }> = [];
+
     try {
       const response = await queryAnalyst(
         {
@@ -153,7 +164,11 @@ export const AnalystChat: React.FC = () => {
         },
         apiKey,
         endpointUrl,
-        undefined, // callbacks - not used yet
+        {
+          onQuery: (query: string) => {
+            processingSteps.push({ type: "query", content: query });
+          },
+        },
         abortControllerRef.current?.signal
       );
 
@@ -183,6 +198,7 @@ export const AnalystChat: React.FC = () => {
             role: "assistant",
             content: formatted.content,
             result: result,
+            processingSteps: processingSteps.length > 0 ? processingSteps : undefined,
           };
         });
         setMessages((prev) => [...prev, ...assistantMessages]);
@@ -558,9 +574,52 @@ export const AnalystChat: React.FC = () => {
                   py={2}
                   borderRadius="lg"
                 >
-                  <Text fontSize="sm" whiteSpace="pre-wrap">
-                    {msg.content}
-                  </Text>
+                  {msg.role === "user" ? (
+                    <Text fontSize="sm" whiteSpace="pre-wrap">
+                      {msg.content}
+                    </Text>
+                  ) : (
+                    <Box fontSize="sm">
+                      <ReactMarkdown
+                        components={{
+                          p: ({ children }) => <Text mb={2}>{children}</Text>,
+                          strong: ({ children }) => <Text as="strong" fontWeight="bold">{children}</Text>,
+                        }}
+                      >
+                        {msg.content}
+                      </ReactMarkdown>
+                    </Box>
+                  )}
+                  {msg.processingSteps && msg.processingSteps.length > 0 && (
+                    <Accordion allowToggle mt={2}>
+                      <AccordionItem border="none">
+                        <AccordionButton px={0} _hover={{ bg: "transparent" }}>
+                          <Box flex="1" textAlign="left" fontSize="xs" fontWeight="medium">
+                            View Queries ({msg.processingSteps.filter(s => s.type === "query").length})
+                          </Box>
+                          <AccordionIcon />
+                        </AccordionButton>
+                        <AccordionPanel px={0} pb={2}>
+                          <VStack align="stretch" spacing={2}>
+                            {msg.processingSteps
+                              .filter(step => step.type === "query")
+                              .map((step, stepIdx) => (
+                                <Code
+                                  key={stepIdx}
+                                  p={2}
+                                  borderRadius="md"
+                                  fontSize="xs"
+                                  whiteSpace="pre-wrap"
+                                  display="block"
+                                >
+                                  {step.content}
+                                </Code>
+                              ))}
+                          </VStack>
+                        </AccordionPanel>
+                      </AccordionItem>
+                    </Accordion>
+                  )}
                   {msg.result && renderCharts(msg.result)}
                   {msg.result && renderTables(msg.result)}
                   {msg.result && renderData(msg.result)}

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -25,12 +25,18 @@ import { CloseIcon, ChatIcon, ChevronDownIcon } from "@chakra-ui/icons";
 import * as React from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { Link as RouterLink } from "react-router-dom";
+import Plotly from "plotly.js-dist-min";
+import createPlotlyComponent from "react-plotly.js/factory";
 import {
   queryAnalyst,
   formatAnalystResult,
   AnalystQueryResult,
+  AnalystChart,
+  AnalystTable,
 } from "@/data/analystClient";
 import { analystApiKey, analystEndpointUrl, analystChatOpen, analystChatMessages, analystSessionId } from "@/data/recoil";
+
+const Plot = createPlotlyComponent(Plotly);
 
 interface Message {
   role: "user" | "assistant";
@@ -236,6 +242,137 @@ export const AnalystChat: React.FC = () => {
     );
   };
 
+  const renderTables = (result: AnalystQueryResult) => {
+    if (!result.tables || result.tables.length === 0) return null;
+
+    return (
+      <>
+        {result.tables.map((table, tableIdx) => {
+          const maxRows = 10;
+          const columns = table.columns.map((col) => col.name);
+          const rows = table.table_data;
+
+          return (
+            <Box key={tableIdx} mt={3}>
+              {table.title && (
+                <Text fontWeight="bold" mb={2} fontSize="sm">
+                  {table.title}
+                </Text>
+              )}
+              <TableContainer maxW="100%" overflowX="auto">
+                <Table size="sm" variant="simple">
+                  <Thead>
+                    <Tr>
+                      {columns.map((col, idx) => (
+                        <Th key={idx}>{col}</Th>
+                      ))}
+                    </Tr>
+                  </Thead>
+                  <Tbody>
+                    {rows.slice(0, maxRows).map((row, rowIdx) => (
+                      <Tr key={rowIdx}>
+                        {row.map((cell, cellIdx) => (
+                          <Td key={cellIdx}>{String(cell)}</Td>
+                        ))}
+                      </Tr>
+                    ))}
+                  </Tbody>
+                </Table>
+                {rows.length > maxRows && (
+                  <Text fontSize="xs" color="gray.500" mt={2}>
+                    Showing {maxRows} of {rows.length} rows
+                  </Text>
+                )}
+              </TableContainer>
+            </Box>
+          );
+        })}
+      </>
+    );
+  };
+
+  const renderCharts = (result: AnalystQueryResult) => {
+    if (!result.charts || result.charts.length === 0) return null;
+
+    // Call hooks at the top level
+    const isDark = useColorModeValue(false, true);
+    const bgColor = useColorModeValue("white", "gray.700");
+    const textColor = useColorModeValue("black", "white");
+
+    return (
+      <>
+        {result.charts.map((chart, chartIdx) => {
+          // Deep clone to avoid frozen object errors
+          const chartCopy = JSON.parse(JSON.stringify(chart));
+
+          // Convert string values to numbers in chart data for Plotly
+          const processedData = chartCopy.figure.data.map((trace: any) => ({
+            ...trace,
+            y: Array.isArray(trace.y)
+              ? trace.y.map((val: any) => {
+                  if (typeof val === "string") {
+                    const parsed = parseFloat(val);
+                    return !isNaN(parsed) ? parsed : val;
+                  }
+                  return val;
+                })
+              : trace.y,
+            x: Array.isArray(trace.x)
+              ? trace.x.map((val: any) => {
+                  if (typeof val === "string") {
+                    const parsed = parseFloat(val);
+                    return !isNaN(parsed) ? parsed : val;
+                  }
+                  return val;
+                })
+              : trace.x,
+          }));
+
+          // Deep clone the layout
+          const layoutCopy = JSON.parse(JSON.stringify(chartCopy.figure.layout));
+
+          const plotLayout = {
+            ...layoutCopy,
+            paper_bgcolor: isDark ? "#2D3748" : "white",
+            plot_bgcolor: isDark ? "#2D3748" : "#E5ECF6",
+            font: {
+              ...layoutCopy.font,
+              color: isDark ? "white" : "#2a3f5f",
+            },
+            autosize: true,
+            margin: { l: 50, r: 50, b: 50, t: 50, pad: 4 },
+          };
+
+          return (
+            <Box
+              key={`chart-${chartIdx}-${chart.title}`}
+              mt={3}
+              width="100%"
+              bg={bgColor}
+              p={2}
+              borderRadius="md"
+            >
+              {chart.title && (
+                <Text fontWeight="bold" mb={2} fontSize="sm" color={textColor}>
+                  {chart.title}
+                </Text>
+              )}
+              <Box width="100%" height="400px">
+                <Plot
+                  key={`plot-${chartIdx}`}
+                  data={processedData}
+                  layout={plotLayout}
+                  config={{ responsive: true, displayModeBar: true }}
+                  style={{ width: "100%", height: "100%" }}
+                />
+              </Box>
+            </Box>
+          );
+        })}
+      </>
+    );
+  };
+
   return (
     <>
       {/* Floating toggle button */}
@@ -401,6 +538,8 @@ export const AnalystChat: React.FC = () => {
                   <Text fontSize="sm" whiteSpace="pre-wrap">
                     {msg.content}
                   </Text>
+                  {msg.result && renderCharts(msg.result)}
+                  {msg.result && renderTables(msg.result)}
                   {msg.result && renderData(msg.result)}
                 </Box>
               </Flex>

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -295,47 +295,71 @@ export const AnalystChat: React.FC = () => {
     );
   };
 
+  // Memoize chart processing to avoid recomputation on every render
+  const processedCharts = React.useMemo(() => {
+    return messages
+      .map((msg) => msg.result?.charts)
+      .filter((charts): charts is AnalystChart[] => !!charts && charts.length > 0)
+      .flat()
+      .map((chart) => {
+        // Deep clone to avoid frozen object errors
+        const chartCopy = JSON.parse(JSON.stringify(chart));
+
+        // Helper: only convert pure numeric strings, not dates or mixed content
+        const maybeParseNumber = (val: any) => {
+          if (typeof val !== "string") return val;
+          const trimmed = val.trim();
+          // Skip if it looks like a date (contains hyphens, slashes, or colons)
+          if (/[-/:]/.test(trimmed)) return val;
+          // Skip if it's not purely numeric (allowing decimals and negatives)
+          if (!/^-?\d+\.?\d*$/.test(trimmed)) return val;
+          const parsed = parseFloat(trimmed);
+          return !isNaN(parsed) ? parsed : val;
+        };
+
+        const processedData = chartCopy.figure.data.map((trace: any) => ({
+          ...trace,
+          y: Array.isArray(trace.y) ? trace.y.map(maybeParseNumber) : trace.y,
+          x: Array.isArray(trace.x) ? trace.x.map(maybeParseNumber) : trace.x,
+        }));
+
+        const layoutCopy = JSON.parse(JSON.stringify(chartCopy.figure.layout));
+
+        return {
+          title: chart.title,
+          data: processedData,
+          layout: layoutCopy,
+        };
+      });
+  }, [messages]);
+
   const renderCharts = (result: AnalystQueryResult) => {
     if (!result.charts || result.charts.length === 0) return null;
 
+    // Find processed charts matching this result
+    const resultCharts = processedCharts.filter((_, idx) => {
+      // Match by scanning messages for this result's charts
+      let chartsSoFar = 0;
+      for (const msg of messages) {
+        if (msg.result === result && result.charts) {
+          return idx >= chartsSoFar && idx < chartsSoFar + result.charts.length;
+        }
+        if (msg.result?.charts) {
+          chartsSoFar += msg.result.charts.length;
+        }
+      }
+      return false;
+    });
+
     return (
       <>
-        {result.charts.map((chart, chartIdx) => {
-          // Deep clone to avoid frozen object errors
-          const chartCopy = JSON.parse(JSON.stringify(chart));
-
-          // Convert string values to numbers in chart data for Plotly
-          const processedData = chartCopy.figure.data.map((trace: any) => ({
-            ...trace,
-            y: Array.isArray(trace.y)
-              ? trace.y.map((val: any) => {
-                  if (typeof val === "string") {
-                    const parsed = parseFloat(val);
-                    return !isNaN(parsed) ? parsed : val;
-                  }
-                  return val;
-                })
-              : trace.y,
-            x: Array.isArray(trace.x)
-              ? trace.x.map((val: any) => {
-                  if (typeof val === "string") {
-                    const parsed = parseFloat(val);
-                    return !isNaN(parsed) ? parsed : val;
-                  }
-                  return val;
-                })
-              : trace.x,
-          }));
-
-          // Deep clone the layout
-          const layoutCopy = JSON.parse(JSON.stringify(chartCopy.figure.layout));
-
+        {resultCharts.map((chart, chartIdx) => {
           const plotLayout = {
-            ...layoutCopy,
+            ...chart.layout,
             paper_bgcolor: chartIsDark ? "#2D3748" : "white",
             plot_bgcolor: chartIsDark ? "#2D3748" : "#E5ECF6",
             font: {
-              ...layoutCopy.font,
+              ...chart.layout.font,
               color: chartIsDark ? "white" : "#2a3f5f",
             },
             autosize: true,
@@ -359,7 +383,7 @@ export const AnalystChat: React.FC = () => {
               <Box width="100%" height="400px">
                 <Plot
                   key={`plot-${chartIdx}`}
-                  data={processedData}
+                  data={chart.data}
                   layout={plotLayout}
                   config={{ responsive: true, displayModeBar: true }}
                   style={{ width: "100%", height: "100%" }}

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -74,6 +74,7 @@ export const AnalystChat: React.FC = () => {
   const chartBgColor = useColorModeValue("white", "gray.700");
   const chartTextColor = useColorModeValue("black", "white");
   const chartIsDark = useColorModeValue(false, true);
+  const reasoningBgColor = useColorModeValue("gray.50", "gray.700");
 
   React.useEffect(() => {
     return () => {
@@ -195,13 +196,14 @@ export const AnalystChat: React.FC = () => {
         setMessages((prev) => [...prev, emptyMessage]);
       } else {
         // Batch all assistant messages into a single state update
-        const assistantMessages: Message[] = response.results.map((result) => {
+        // Only attach processingSteps to the first result to avoid duplication
+        const assistantMessages: Message[] = response.results.map((result, idx) => {
           const formatted = formatAnalystResult(result);
           return {
             role: "assistant",
             content: formatted.content,
             result: result,
-            processingSteps: processingSteps.length > 0 ? processingSteps : undefined,
+            processingSteps: idx === 0 && processingSteps.length > 0 ? processingSteps : undefined,
           };
         });
         setMessages((prev) => [...prev, ...assistantMessages]);
@@ -321,6 +323,15 @@ export const AnalystChat: React.FC = () => {
       .filter((charts): charts is AnalystChart[] => !!charts && charts.length > 0)
       .flat()
       .map((chart) => {
+        // Guard against malformed charts
+        if (!chart.figure || !chart.figure.data || !Array.isArray(chart.figure.data)) {
+          return {
+            title: chart.title || "Malformed chart",
+            data: [],
+            layout: {},
+          };
+        }
+
         // Deep clone to avoid frozen object errors
         const chartCopy = JSON.parse(JSON.stringify(chart));
 
@@ -342,7 +353,7 @@ export const AnalystChat: React.FC = () => {
           x: Array.isArray(trace.x) ? trace.x.map(maybeParseNumber) : trace.x,
         }));
 
-        const layoutCopy = JSON.parse(JSON.stringify(chartCopy.figure.layout));
+        const layoutCopy = JSON.parse(JSON.stringify(chartCopy.figure.layout || {}));
 
         return {
           title: chart.title,
@@ -614,7 +625,7 @@ export const AnalystChat: React.FC = () => {
                                     borderRadius="md"
                                     fontSize="xs"
                                     whiteSpace="pre-wrap"
-                                    bg={useColorModeValue("gray.50", "gray.700")}
+                                    bg={reasoningBgColor}
                                     borderLeft="3px solid"
                                     borderColor="purple.400"
                                   >

--- a/web/src/data/analystClient.ts
+++ b/web/src/data/analystClient.ts
@@ -65,6 +65,7 @@ export interface StreamCallback {
   onChart?: (chart: AnalystChart) => void;
   onFollowUpQueries?: (queries: string[]) => void;
   onQuery?: (query: string) => void;
+  onReasoning?: (reasoning: string) => void;
 }
 
 /**
@@ -141,8 +142,13 @@ export async function queryAnalyst(
         try {
           const parsed = JSON.parse(data);
 
-          // Capture SQL query from reasoning events
+          // Capture reasoning and SQL query from reasoning events
           if (parsed.type === "response.reasoning.done" && parsed.text) {
+            // Send full reasoning text to callback
+            if (callbacks?.onReasoning) {
+              callbacks.onReasoning(parsed.text);
+            }
+
             // Extract SQL query from the reasoning text
             const sqlMatch = parsed.text.match(/```sql\s*([\s\S]*?)\s*```/);
             if (sqlMatch && sqlMatch[1]) {

--- a/web/src/data/queries.ts
+++ b/web/src/data/queries.ts
@@ -371,17 +371,20 @@ export const checkPlans = async (config: ConnectionConfig) => {
     `
   );
 
-  try {
-    await Promise.all(
-      badPlans.map(({ planId }) =>
-        Exec(config, `DROP ${planId} FROM PLANCACHE`)
-      )
-    );
-  } catch (e) {
-    if (!(e instanceof SQLError && e.isPlanMissing())) {
-      throw e;
-    }
-  }
+  // Drop each plan individually, ignoring "plan missing" errors
+  // This prevents one failed drop from blocking others
+  await Promise.all(
+    badPlans.map(async ({ planId }) => {
+      try {
+        await Exec(config, `DROP ${planId} FROM PLANCACHE`);
+      } catch (e) {
+        // Silently ignore if plan was already dropped
+        if (!(e instanceof SQLError && e.isPlanMissing())) {
+          throw e;
+        }
+      }
+    })
+  );
 
   return badPlans.length > 0;
 };

--- a/web/src/data/recoil.ts
+++ b/web/src/data/recoil.ts
@@ -238,7 +238,7 @@ export const analystChatMessages = atom<Array<{
   role: "user" | "assistant";
   content: string;
   result?: any;
-  processingSteps?: Array<{ type: "status" | "query"; content: string }>;
+  processingSteps?: Array<{ type: "status" | "query" | "reasoning"; content: string }>;
 }>>({
   key: "analystChatMessages",
   default: [],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI and streaming-display changes only; no auth or backend changes. Multiple `results` entries may still appear as separate messages (documented separately).
> 
> **Overview**
> Improves the **Aura Analyst** chat by streaming **reasoning** and **SQL** from the Analyst API and showing them in collapsible **View Reasoning** / **View Queries** sections on the first assistant message in a batch (so steps are not repeated across multiple results).
> 
> Assistant replies now render with **ReactMarkdown** instead of plain text. **Plotly** chart handling is hardened when `figure` / `data` / `layout` are missing or invalid.
> 
> The streaming client adds an **`onReasoning`** callback for `response.reasoning.done` events (SQL extraction from reasoning is unchanged). Recoil message types include **`reasoning`** in `processingSteps`. **`ANALYST_FIXES_NEEDED.md`** documents known Analyst issues (duplicate chat history, Chat Review duplicates, API key masking)—the Configure obfuscation change is not in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df55b955513dd8cf158e3a8774a996eee7b267e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->