### PR TITLE
Akwong/streaming chain of thought

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import { Navigate, Route, Routes } from "react-router-dom";
 import { useRecoilState } from "recoil";
 
 import { useAnalytics } from "@/analytics";
+import { AnalystChat } from "@/components/AnalystChat";
 import { Loader } from "@/components/customcomponents/loader/Loader";
 import { Footer } from "@/components/Footer";
 import { Nav } from "@/components/navBar/Nav";
@@ -125,6 +126,7 @@ const LayoutContainer = ({ children }: { children: React.ReactNode }) => {
         {childComponent}
       </Box>
       <Footer />
+      {connected && <AnalystChat />}
     </>
   );
 };

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -186,16 +186,17 @@ export const AnalystChat: React.FC = () => {
     };
   }, [isResizing]);
 
-  const handleSend = async () => {
-    if (!input.trim() || isLoading || isProcessingRef.current) return;
+  const handleSend = async (messageOverride?: string) => {
+    const messageToSend = messageOverride || input;
+    if (!messageToSend.trim() || isLoading || isProcessingRef.current) return;
 
     if (!apiKey || !endpointUrl) {
       return;
     }
 
     isProcessingRef.current = true;
-    const userMessage: Message = { role: "user", content: input };
-    const messageText = input;
+    const userMessage: Message = { role: "user", content: messageToSend };
+    const messageText = messageToSend;
     const requestSessionId = sessionId;
     setMessages((prev) => [...prev, userMessage]);
     setInput("");
@@ -238,7 +239,7 @@ export const AnalystChat: React.FC = () => {
                     ...msg,
                     streamingSteps: [
                       ...(msg.streamingSteps || []),
-                      { type: "reasoning", content: reasoning, timestamp: Date.now() }
+                      { type: "reasoning" as const, content: reasoning, timestamp: Date.now() }
                     ]
                   };
                 }
@@ -258,7 +259,7 @@ export const AnalystChat: React.FC = () => {
                     ...msg,
                     streamingSteps: [
                       ...(msg.streamingSteps || []),
-                      { type: "query", content: query, timestamp: Date.now() }
+                      { type: "query" as const, content: query, timestamp: Date.now() }
                     ]
                   };
                 }
@@ -498,7 +499,7 @@ export const AnalystChat: React.FC = () => {
               color: chartIsDark ? "white" : "#2a3f5f",
             },
             autosize: true,
-            margin: { l: 50, r: 50, b: 50, t: 50, pad: 4 },
+            margin: { l: 50, r: 50, b: 50, t: 80, pad: 4 },
           };
 
           return (
@@ -831,6 +832,37 @@ export const AnalystChat: React.FC = () => {
                   {msg.result && renderCharts(msg.result)}
                   {msg.result && renderTables(msg.result)}
                   {msg.result && renderData(msg.result)}
+                  {msg.result?.followUpQueries && msg.result.followUpQueries.length > 0 && (
+                    <VStack align="stretch" spacing={2} mt={3} pt={3} borderTop="1px solid" borderColor={borderColor}>
+                      <Text fontSize="xs" fontWeight="bold" color="gray.600">
+                        💡 You might also ask:
+                      </Text>
+                      {msg.result.followUpQueries.slice(0, 3).map((question: string, qIdx: number) => (
+                        <Button
+                          key={qIdx}
+                          size="sm"
+                          variant="outline"
+                          colorScheme="purple"
+                          justifyContent="flex-start"
+                          textAlign="left"
+                          whiteSpace="normal"
+                          height="auto"
+                          py={2}
+                          px={3}
+                          fontSize="xs"
+                          onClick={() => {
+                            if (!isLoading && !isProcessingRef.current) {
+                              handleSend(question);
+                            }
+                          }}
+                          disabled={isLoading || isProcessingRef.current}
+                          _hover={{ bg: useColorModeValue("purple.50", "purple.900") }}
+                        >
+                          {question}
+                        </Button>
+                      ))}
+                    </VStack>
+                  )}
                 </Box>
               </Flex>
             ))}
@@ -853,7 +885,7 @@ export const AnalystChat: React.FC = () => {
             />
             <Button
               colorScheme="purple"
-              onClick={handleSend}
+              onClick={() => handleSend()}
               disabled={isLoading || !input.trim()}
             >
               Send

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -50,7 +50,33 @@ interface Message {
   content: string;
   result?: AnalystQueryResult;
   processingSteps?: Array<{ type: "status" | "query" | "reasoning"; content: string }>;
+  isStreaming?: boolean;
+  streamingSteps?: Array<{ type: "status" | "query" | "reasoning"; content: string; timestamp: number }>;
 }
+
+// Fun thinking status messages inspired by Claude
+const THINKING_STATUSES = [
+  "Thinking",
+  "Pondering",
+  "Cogitating",
+  "Contemplating",
+  "Ruminating",
+  "Analyzing",
+  "Processing",
+  "Deliberating",
+  "Examining",
+  "Investigating",
+  "Mulling over",
+  "Reflecting",
+  "Scrutinizing",
+  "Perusing",
+  "Reasoning",
+  "Calculating",
+  "Computing",
+  "Evaluating",
+  "Puzzling through",
+  "Working on it",
+];
 
 export const AnalystChat: React.FC = () => {
   const apiKey = useRecoilValue(analystApiKey);
@@ -60,12 +86,14 @@ export const AnalystChat: React.FC = () => {
   const [sessionId, setSessionId] = useRecoilState(analystSessionId);
   const [input, setInput] = React.useState("");
   const [isLoading, setIsLoading] = React.useState(false);
+  const [currentThinkingStatus, setCurrentThinkingStatus] = React.useState("Thinking");
   const abortControllerRef = React.useRef<AbortController | null>(null);
   const [size, setSize] = React.useState({ width: 450, height: 600 });
   const [isResizing, setIsResizing] = React.useState(false);
   const isMountedRef = React.useRef(true);
   const isProcessingRef = React.useRef(false);
   const currentSessionIdRef = React.useRef(sessionId);
+  const thinkingIntervalRef = React.useRef<NodeJS.Timeout | null>(null);
 
   const bgColor = useColorModeValue("white", "gray.800");
   const borderColor = useColorModeValue("gray.200", "gray.600");
@@ -79,8 +107,31 @@ export const AnalystChat: React.FC = () => {
   React.useEffect(() => {
     return () => {
       isMountedRef.current = false;
+      if (thinkingIntervalRef.current) {
+        clearInterval(thinkingIntervalRef.current);
+      }
     };
   }, []);
+
+  // Rotate thinking status messages
+  React.useEffect(() => {
+    if (isLoading) {
+      thinkingIntervalRef.current = setInterval(() => {
+        setCurrentThinkingStatus(
+          THINKING_STATUSES[Math.floor(Math.random() * THINKING_STATUSES.length)]
+        );
+      }, 2000);
+    } else if (thinkingIntervalRef.current) {
+      clearInterval(thinkingIntervalRef.current);
+      thinkingIntervalRef.current = null;
+    }
+
+    return () => {
+      if (thinkingIntervalRef.current) {
+        clearInterval(thinkingIntervalRef.current);
+      }
+    };
+  }, [isLoading]);
 
   // Keep session ID ref in sync with Recoil state
   React.useEffect(() => {
@@ -156,6 +207,16 @@ export const AnalystChat: React.FC = () => {
     // Track processing steps (reasoning and queries executed)
     const processingSteps: Array<{ type: "status" | "query" | "reasoning"; content: string }> = [];
 
+    // Create a streaming assistant message that will be updated in real-time
+    const streamingMessageIndex = messages.length + 1;
+    const streamingMessage: Message = {
+      role: "assistant",
+      content: "",
+      isStreaming: true,
+      streamingSteps: [],
+    };
+    setMessages((prev) => [...prev, streamingMessage]);
+
     try {
       const response = await queryAnalyst(
         {
@@ -168,9 +229,33 @@ export const AnalystChat: React.FC = () => {
         {
           onReasoning: (reasoning: string) => {
             processingSteps.push({ type: "reasoning", content: reasoning });
+            // Update the streaming message with new reasoning in real-time
+            setMessages((prev) => {
+              const updated = [...prev];
+              const msg = updated[streamingMessageIndex];
+              if (msg && msg.isStreaming) {
+                msg.streamingSteps = [
+                  ...(msg.streamingSteps || []),
+                  { type: "reasoning", content: reasoning, timestamp: Date.now() }
+                ];
+              }
+              return updated;
+            });
           },
           onQuery: (query: string) => {
             processingSteps.push({ type: "query", content: query });
+            // Update the streaming message with new query in real-time
+            setMessages((prev) => {
+              const updated = [...prev];
+              const msg = updated[streamingMessageIndex];
+              if (msg && msg.isStreaming) {
+                msg.streamingSteps = [
+                  ...(msg.streamingSteps || []),
+                  { type: "query", content: query, timestamp: Date.now() }
+                ];
+              }
+              return updated;
+            });
           },
         },
         abortControllerRef.current?.signal
@@ -195,18 +280,26 @@ export const AnalystChat: React.FC = () => {
         };
         setMessages((prev) => [...prev, emptyMessage]);
       } else {
-        // Batch all assistant messages into a single state update
-        // Only attach processingSteps to the first result to avoid duplication
-        const assistantMessages: Message[] = response.results.map((result, idx) => {
-          const formatted = formatAnalystResult(result);
-          return {
-            role: "assistant",
-            content: formatted.content,
-            result: result,
-            processingSteps: idx === 0 && processingSteps.length > 0 ? processingSteps : undefined,
-          };
+        // Update the streaming message to show final results
+        setMessages((prev) => {
+          const updated = [...prev];
+          // Remove the streaming message
+          updated.splice(streamingMessageIndex, 1);
+
+          // Add final assistant messages
+          const assistantMessages: Message[] = response.results.map((result, idx) => {
+            const formatted = formatAnalystResult(result);
+            return {
+              role: "assistant",
+              content: formatted.content,
+              result: result,
+              processingSteps: idx === 0 && processingSteps.length > 0 ? processingSteps : undefined,
+              isStreaming: false,
+            };
+          });
+
+          return [...updated, ...assistantMessages];
         });
-        setMessages((prev) => [...prev, ...assistantMessages]);
       }
     } catch (error) {
       if (!isMountedRef.current) return;
@@ -594,6 +687,48 @@ export const AnalystChat: React.FC = () => {
                     <Text fontSize="sm" whiteSpace="pre-wrap">
                       {msg.content}
                     </Text>
+                  ) : msg.isStreaming ? (
+                    <VStack align="stretch" spacing={2}>
+                      <Flex alignItems="center" gap={2}>
+                        <Spinner size="sm" />
+                        <Text fontSize="sm" fontWeight="medium">{currentThinkingStatus}...</Text>
+                      </Flex>
+                      {msg.streamingSteps && msg.streamingSteps.length > 0 && (
+                        <VStack align="stretch" spacing={1} mt={2}>
+                          {msg.streamingSteps.map((step, stepIdx) => (
+                            <Box
+                              key={stepIdx}
+                              p={2}
+                              borderRadius="md"
+                              fontSize="xs"
+                              bg={reasoningBgColor}
+                              borderLeft="3px solid"
+                              borderColor={step.type === "query" ? "blue.400" : "purple.400"}
+                            >
+                              <Flex alignItems="center" gap={1} mb={1}>
+                                <Text fontWeight="bold">
+                                  {step.type === "query" ? "🔍 Running query" : "💭 Reasoning"}
+                                </Text>
+                              </Flex>
+                              {step.type === "query" ? (
+                                <Code
+                                  fontSize="xs"
+                                  whiteSpace="pre-wrap"
+                                  display="block"
+                                  p={1}
+                                >
+                                  {step.content}
+                                </Code>
+                              ) : (
+                                <Text whiteSpace="pre-wrap" noOfLines={3}>
+                                  {step.content}
+                                </Text>
+                              )}
+                            </Box>
+                          ))}
+                        </VStack>
+                      )}
+                    </VStack>
                   ) : (
                     <Box fontSize="sm">
                       <ReactMarkdown
@@ -606,7 +741,7 @@ export const AnalystChat: React.FC = () => {
                       </ReactMarkdown>
                     </Box>
                   )}
-                  {msg.processingSteps && msg.processingSteps.length > 0 && (
+                  {!msg.isStreaming && msg.processingSteps && msg.processingSteps.length > 0 && (
                     <Accordion allowToggle mt={2}>
                       {msg.processingSteps.some(s => s.type === "reasoning") && (
                         <AccordionItem border="none">
@@ -689,22 +824,6 @@ export const AnalystChat: React.FC = () => {
                 </Box>
               </Flex>
             ))}
-            {isLoading && (
-              <Flex justifyContent="flex-start">
-                <Box
-                  bg={assistantBgColor}
-                  px={4}
-                  py={2}
-                  borderRadius="lg"
-                  display="flex"
-                  alignItems="center"
-                  gap={2}
-                >
-                  <Spinner size="sm" />
-                  <Text fontSize="sm">Thinking...</Text>
-                </Box>
-              </Flex>
-            )}
             <div ref={messagesEndRef} />
           </VStack>
 

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -78,6 +78,11 @@ const THINKING_STATUSES = [
   "Working on it",
 ];
 
+// Helper function to clean reasoning text by removing redundant headers
+const cleanReasoningText = (text: string): string => {
+  return text.replace(/^\*\*Reasoning:\*\*\s*/i, '').trim();
+};
+
 export const AnalystChat: React.FC = () => {
   const apiKey = useRecoilValue(analystApiKey);
   const endpointUrl = useRecoilValue(analystEndpointUrl);
@@ -205,6 +210,14 @@ export const AnalystChat: React.FC = () => {
     // Create abort controller for this request
     abortControllerRef.current = new AbortController();
 
+    // Set a 2 minute timeout
+    const timeoutId = setTimeout(() => {
+      console.log('[Analyst] Request timeout after 2 minutes');
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+    }, 120000); // 2 minutes
+
     // Track processing steps (reasoning and queries executed)
     const processingSteps: Array<{ type: "status" | "query" | "reasoning"; content: string }> = [];
 
@@ -272,25 +285,38 @@ export const AnalystChat: React.FC = () => {
         abortControllerRef.current?.signal
       );
 
-      // Ignore response if session has changed (chat was cleared)
-      if (requestSessionId !== currentSessionIdRef.current) return;
+      console.log('[Analyst] Query complete, processing response');
 
-      if (!isMountedRef.current) return;
+      // Ignore response if session has changed (chat was cleared)
+      if (requestSessionId !== currentSessionIdRef.current) {
+        console.log('[Analyst] Session changed, ignoring response');
+        return;
+      }
+
+      if (!isMountedRef.current) {
+        console.log('[Analyst] Component unmounted, ignoring response');
+        return;
+      }
+
+      console.log('[Analyst] Response results:', response.results?.length || 0);
 
       // Handle multiple results (agent can return more than one)
       if (!response.results || !Array.isArray(response.results)) {
+        console.log('[Analyst] Malformed response');
         const malformedMessage: Message = {
           role: "assistant",
           content: "Received malformed response from Analyst API.",
         };
         setMessages((prev) => [...prev, malformedMessage]);
       } else if (response.results.length === 0) {
+        console.log('[Analyst] Empty results');
         const emptyMessage: Message = {
           role: "assistant",
           content: "The agent returned no results.",
         };
         setMessages((prev) => [...prev, emptyMessage]);
       } else {
+        console.log('[Analyst] Updating UI with results');
         // Update the streaming message to show final results
         setMessages((prev) => {
           const updated = [...prev];
@@ -311,20 +337,49 @@ export const AnalystChat: React.FC = () => {
 
           return [...updated, ...assistantMessages];
         });
+        console.log('[Analyst] UI update complete');
       }
     } catch (error) {
+      clearTimeout(timeoutId);
       if (!isMountedRef.current) return;
-      // Ignore aborted requests
-      if (error instanceof Error && error.name === 'AbortError') return;
+
+      // Handle aborted requests
+      if (error instanceof Error && error.name === 'AbortError') {
+        console.log('[Analyst] Request was aborted');
+        // Remove streaming message and show timeout error
+        if (requestSessionId === currentSessionIdRef.current) {
+          setMessages((prev) => {
+            const updated = [...prev];
+            updated.splice(streamingMessageIndex, 1);
+            return [
+              ...updated,
+              {
+                role: "assistant",
+                content: "Request timed out after 2 minutes. Please try a simpler question or check your connection.",
+              }
+            ];
+          });
+        }
+        return;
+      }
+
       // Ignore errors if session changed (chat was cleared)
       if (requestSessionId !== currentSessionIdRef.current) return;
 
-      const errorMessage: Message = {
-        role: "assistant",
-        content: `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
-      };
-      setMessages((prev) => [...prev, errorMessage]);
+      // Remove streaming message and show error
+      setMessages((prev) => {
+        const updated = [...prev];
+        updated.splice(streamingMessageIndex, 1);
+        return [
+          ...updated,
+          {
+            role: "assistant",
+            content: `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
+          }
+        ];
+      });
     } finally {
+      clearTimeout(timeoutId);
       // Only update state if this request is still valid (session hasn't changed)
       if (requestSessionId === currentSessionIdRef.current) {
         isProcessingRef.current = false;
@@ -732,7 +787,7 @@ export const AnalystChat: React.FC = () => {
                                 </Code>
                               ) : (
                                 <Text whiteSpace="pre-wrap" noOfLines={3}>
-                                  {step.content}
+                                  {cleanReasoningText(step.content)}
                                 </Text>
                               )}
                             </Box>
@@ -790,7 +845,7 @@ export const AnalystChat: React.FC = () => {
                                           ),
                                       }}
                                     >
-                                      {step.content}
+                                      {cleanReasoningText(step.content)}
                                     </ReactMarkdown>
                                   </Box>
                                 ))}

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -299,7 +299,17 @@ export const AnalystChat: React.FC = () => {
       }
 
       if (!isMountedRef.current) {
-        console.log('[Analyst] Component unmounted, ignoring response');
+        console.log('[Analyst] Component unmounted, cleaning up streaming message');
+        // Remove streaming message even though component is unmounted
+        // This prevents orphaned streaming state in Recoil localStorage
+        setMessages((prev) => {
+          const updated = [...prev];
+          const streamingIdx = updated.findIndex(msg => msg.isStreaming);
+          if (streamingIdx !== -1) {
+            updated.splice(streamingIdx, 1);
+          }
+          return updated;
+        });
         return;
       }
 
@@ -311,7 +321,10 @@ export const AnalystChat: React.FC = () => {
         // Remove streaming message and show error
         setMessages((prev) => {
           const updated = [...prev];
-          updated.splice(streamingMessageIndex, 1);
+          const streamingIdx = updated.findIndex(msg => msg.isStreaming);
+          if (streamingIdx !== -1) {
+            updated.splice(streamingIdx, 1);
+          }
           return [
             ...updated,
             {
@@ -325,7 +338,10 @@ export const AnalystChat: React.FC = () => {
         // Remove streaming message and show error
         setMessages((prev) => {
           const updated = [...prev];
-          updated.splice(streamingMessageIndex, 1);
+          const streamingIdx = updated.findIndex(msg => msg.isStreaming);
+          if (streamingIdx !== -1) {
+            updated.splice(streamingIdx, 1);
+          }
           return [
             ...updated,
             {
@@ -340,7 +356,10 @@ export const AnalystChat: React.FC = () => {
         setMessages((prev) => {
           const updated = [...prev];
           // Remove the streaming message
-          updated.splice(streamingMessageIndex, 1);
+          const streamingIdx = updated.findIndex(msg => msg.isStreaming);
+          if (streamingIdx !== -1) {
+            updated.splice(streamingIdx, 1);
+          }
 
           // Add final assistant messages
           const assistantMessages: Message[] = response.results.map((result, idx) => {
@@ -360,17 +379,40 @@ export const AnalystChat: React.FC = () => {
       }
     } catch (error) {
       clearTimeout(timeoutId);
-      if (!isMountedRef.current) return;
+
+      if (!isMountedRef.current) {
+        console.log('[Analyst] Component unmounted during error, cleaning up');
+        // Remove streaming message even though component is unmounted
+        setMessages((prev) => {
+          const updated = [...prev];
+          const streamingIdx = updated.findIndex(msg => msg.isStreaming);
+          if (streamingIdx !== -1) {
+            updated.splice(streamingIdx, 1);
+          }
+          return updated;
+        });
+        return;
+      }
+
+      // Ignore errors if session changed (chat was cleared)
+      if (requestSessionId !== currentSessionIdRef.current) {
+        console.log('[Analyst] Session changed, ignoring error');
+        return;
+      }
 
       // Handle aborted requests
       if (error instanceof Error && error.name === 'AbortError') {
         console.log('[Analyst] Request was aborted');
 
         // Only show timeout message if it was actually a timeout (not user clearing chat)
-        if (wasTimedOut && requestSessionId === currentSessionIdRef.current) {
+        if (wasTimedOut) {
           setMessages((prev) => {
             const updated = [...prev];
-            updated.splice(streamingMessageIndex, 1);
+            // Find and remove the streaming message by checking isStreaming flag
+            const streamingIdx = updated.findIndex(msg => msg.isStreaming);
+            if (streamingIdx !== -1) {
+              updated.splice(streamingIdx, 1);
+            }
             return [
               ...updated,
               {
@@ -380,23 +422,26 @@ export const AnalystChat: React.FC = () => {
             ];
           });
         } else {
-          // User cleared chat - just remove the streaming message silently
+          // User cleared chat or other abort - remove streaming message silently
           setMessages((prev) => {
             const updated = [...prev];
-            updated.splice(streamingMessageIndex, 1);
+            const streamingIdx = updated.findIndex(msg => msg.isStreaming);
+            if (streamingIdx !== -1) {
+              updated.splice(streamingIdx, 1);
+            }
             return updated;
           });
         }
         return;
       }
 
-      // Ignore errors if session changed (chat was cleared)
-      if (requestSessionId !== currentSessionIdRef.current) return;
-
       // Remove streaming message and show error
       setMessages((prev) => {
         const updated = [...prev];
-        updated.splice(streamingMessageIndex, 1);
+        const streamingIdx = updated.findIndex(msg => msg.isStreaming);
+        if (streamingIdx !== -1) {
+          updated.splice(streamingIdx, 1);
+        }
         return [
           ...updated,
           {

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -108,6 +108,9 @@ export const AnalystChat: React.FC = () => {
   const chartTextColor = useColorModeValue("black", "white");
   const chartIsDark = useColorModeValue(false, true);
   const reasoningBgColor = useColorModeValue("gray.50", "gray.700");
+  const followUpButtonHoverBg = useColorModeValue("purple.50", "purple.900");
+  const followUpTextColor = useColorModeValue("gray.600", "gray.400");
+  const clearChatTextColor = useColorModeValue("gray.800", "white");
 
   React.useEffect(() => {
     return () => {
@@ -211,8 +214,10 @@ export const AnalystChat: React.FC = () => {
     abortControllerRef.current = new AbortController();
 
     // Set a 2 minute timeout
+    let wasTimedOut = false;
     const timeoutId = setTimeout(() => {
       console.log('[Analyst] Request timeout after 2 minutes');
+      wasTimedOut = true;
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
       }
@@ -303,18 +308,32 @@ export const AnalystChat: React.FC = () => {
       // Handle multiple results (agent can return more than one)
       if (!response.results || !Array.isArray(response.results)) {
         console.log('[Analyst] Malformed response');
-        const malformedMessage: Message = {
-          role: "assistant",
-          content: "Received malformed response from Analyst API.",
-        };
-        setMessages((prev) => [...prev, malformedMessage]);
+        // Remove streaming message and show error
+        setMessages((prev) => {
+          const updated = [...prev];
+          updated.splice(streamingMessageIndex, 1);
+          return [
+            ...updated,
+            {
+              role: "assistant",
+              content: "Received malformed response from Analyst API.",
+            }
+          ];
+        });
       } else if (response.results.length === 0) {
         console.log('[Analyst] Empty results');
-        const emptyMessage: Message = {
-          role: "assistant",
-          content: "The agent returned no results.",
-        };
-        setMessages((prev) => [...prev, emptyMessage]);
+        // Remove streaming message and show error
+        setMessages((prev) => {
+          const updated = [...prev];
+          updated.splice(streamingMessageIndex, 1);
+          return [
+            ...updated,
+            {
+              role: "assistant",
+              content: "The agent returned no results.",
+            }
+          ];
+        });
       } else {
         console.log('[Analyst] Updating UI with results');
         // Update the streaming message to show final results
@@ -346,8 +365,9 @@ export const AnalystChat: React.FC = () => {
       // Handle aborted requests
       if (error instanceof Error && error.name === 'AbortError') {
         console.log('[Analyst] Request was aborted');
-        // Remove streaming message and show timeout error
-        if (requestSessionId === currentSessionIdRef.current) {
+
+        // Only show timeout message if it was actually a timeout (not user clearing chat)
+        if (wasTimedOut && requestSessionId === currentSessionIdRef.current) {
           setMessages((prev) => {
             const updated = [...prev];
             updated.splice(streamingMessageIndex, 1);
@@ -358,6 +378,13 @@ export const AnalystChat: React.FC = () => {
                 content: "Request timed out after 2 minutes. Please try a simpler question or check your connection.",
               }
             ];
+          });
+        } else {
+          // User cleared chat - just remove the streaming message silently
+          setMessages((prev) => {
+            const updated = [...prev];
+            updated.splice(streamingMessageIndex, 1);
+            return updated;
           });
         }
         return;
@@ -687,7 +714,7 @@ export const AnalystChat: React.FC = () => {
                       setSessionId(crypto.randomUUID());
                       setIsLoading(false);
                     }}
-                    color={useColorModeValue("gray.800", "white")}
+                    color={clearChatTextColor}
                     fontWeight="medium"
                   >
                     Clear Chat
@@ -889,7 +916,7 @@ export const AnalystChat: React.FC = () => {
                   {msg.result && renderData(msg.result)}
                   {msg.result?.followUpQueries && msg.result.followUpQueries.length > 0 && (
                     <VStack align="stretch" spacing={2} mt={3} pt={3} borderTop="1px solid" borderColor={borderColor}>
-                      <Text fontSize="xs" fontWeight="bold" color="gray.600">
+                      <Text fontSize="xs" fontWeight="bold" color={followUpTextColor}>
                         💡 You might also ask:
                       </Text>
                       {msg.result.followUpQueries.slice(0, 3).map((question: string, qIdx: number) => (
@@ -911,7 +938,7 @@ export const AnalystChat: React.FC = () => {
                             }
                           }}
                           disabled={isLoading || isProcessingRef.current}
-                          _hover={{ bg: useColorModeValue("purple.50", "purple.900") }}
+                          _hover={{ bg: followUpButtonHoverBg }}
                         >
                           {question}
                         </Button>

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -120,7 +120,7 @@ export const AnalystChat: React.FC = () => {
         setCurrentThinkingStatus(
           THINKING_STATUSES[Math.floor(Math.random() * THINKING_STATUSES.length)]
         );
-      }, 2000);
+      }, 4000); // Changed from 2000ms to 4000ms
     } else if (thinkingIntervalRef.current) {
       clearInterval(thinkingIntervalRef.current);
       thinkingIntervalRef.current = null;
@@ -228,32 +228,42 @@ export const AnalystChat: React.FC = () => {
         endpointUrl,
         {
           onReasoning: (reasoning: string) => {
+            console.log('[Analyst] Received reasoning:', reasoning.substring(0, 100));
             processingSteps.push({ type: "reasoning", content: reasoning });
             // Update the streaming message with new reasoning in real-time
             setMessages((prev) => {
-              const updated = [...prev];
-              const msg = updated[streamingMessageIndex];
-              if (msg && msg.isStreaming) {
-                msg.streamingSteps = [
-                  ...(msg.streamingSteps || []),
-                  { type: "reasoning", content: reasoning, timestamp: Date.now() }
-                ];
-              }
+              const updated = prev.map((msg, idx) => {
+                if (idx === streamingMessageIndex && msg.isStreaming) {
+                  return {
+                    ...msg,
+                    streamingSteps: [
+                      ...(msg.streamingSteps || []),
+                      { type: "reasoning", content: reasoning, timestamp: Date.now() }
+                    ]
+                  };
+                }
+                return msg;
+              });
               return updated;
             });
           },
           onQuery: (query: string) => {
+            console.log('[Analyst] Received query:', query.substring(0, 100));
             processingSteps.push({ type: "query", content: query });
             // Update the streaming message with new query in real-time
             setMessages((prev) => {
-              const updated = [...prev];
-              const msg = updated[streamingMessageIndex];
-              if (msg && msg.isStreaming) {
-                msg.streamingSteps = [
-                  ...(msg.streamingSteps || []),
-                  { type: "query", content: query, timestamp: Date.now() }
-                ];
-              }
+              const updated = prev.map((msg, idx) => {
+                if (idx === streamingMessageIndex && msg.isStreaming) {
+                  return {
+                    ...msg,
+                    streamingSteps: [
+                      ...(msg.streamingSteps || []),
+                      { type: "query", content: query, timestamp: Date.now() }
+                    ]
+                  };
+                }
+                return msg;
+              });
               return updated;
             });
           },

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -112,6 +112,18 @@ export const AnalystChat: React.FC = () => {
   const followUpTextColor = useColorModeValue("gray.600", "gray.400");
   const clearChatTextColor = useColorModeValue("gray.800", "white");
 
+  // Clean up orphaned streaming messages on mount (from page reload/close during request)
+  React.useEffect(() => {
+    setMessages((prev) => {
+      const hasStreaming = prev.some(msg => msg.isStreaming);
+      if (hasStreaming) {
+        console.log('[Analyst] Cleaning up orphaned streaming messages from previous session');
+        return prev.filter(msg => !msg.isStreaming);
+      }
+      return prev;
+    });
+  }, [setMessages]);
+
   React.useEffect(() => {
     return () => {
       isMountedRef.current = false;

--- a/web/src/data/analystClient.ts
+++ b/web/src/data/analystClient.ts
@@ -119,14 +119,24 @@ export async function queryAnalyst(
   const tables: AnalystTable[] = [];
   const charts: AnalystChart[] = [];
   let followUpQueries: string[] = [];
+  let chunkCount = 0;
 
   if (!reader) {
     throw new Error("Response body is not readable");
   }
 
+  console.log("[Analyst] Starting to read streaming response");
+
   while (true) {
     const { done, value } = await reader.read();
-    if (done) break;
+    chunkCount++;
+    if (chunkCount % 10 === 0) {
+      console.log(`[Analyst] Processed ${chunkCount} chunks`);
+    }
+    if (done) {
+      console.log(`[Analyst] Stream complete after ${chunkCount} chunks`);
+      break;
+    }
 
     buffer += decoder.decode(value, { stream: true });
     const lines = buffer.split("\n");

--- a/web/src/data/recoil.ts
+++ b/web/src/data/recoil.ts
@@ -239,6 +239,8 @@ export const analystChatMessages = atom<Array<{
   content: string;
   result?: any;
   processingSteps?: Array<{ type: "status" | "query" | "reasoning"; content: string }>;
+  isStreaming?: boolean;
+  streamingSteps?: Array<{ type: "status" | "query" | "reasoning"; content: string; timestamp: number }>;
 }>>({
   key: "analystChatMessages",
   default: [],

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -40,7 +40,6 @@ import { Loader } from "@/components/customcomponents/loader/Loader";
 import { EnableSimulatorWarning } from "@/components/EnableSimulatorButton";
 import { Heatmap } from "@/components/HeatMap";
 import { SetupDatabaseButton } from "@/components/SetupDatabaseButton";
-import { AnalystChat } from "@/components/AnalystChat";
 import {
   CustomerMetrics,
   customerMetrics,
@@ -420,12 +419,9 @@ export const AnalyticsDashboard = () => {
   const [isSmallScreen] = useMediaQuery("(max-width: 640px)");
 
   return (
-    <>
-      <Container maxW={isSmallScreen ? undefined : "75%"} mt={10} mb="5%">
-        <DashboardContainerChild />
-      </Container>
-      <AnalystChat />
-    </>
+    <Container maxW={isSmallScreen ? undefined : "75%"} mt={10} mb="5%">
+      <DashboardContainerChild />
+    </Container>
   );
 };
 

--- a/web/src/view/hooks/hooks.ts
+++ b/web/src/view/hooks/hooks.ts
@@ -133,13 +133,16 @@ export const useTick = (
         if (e instanceof DOMException && e.name === "AbortError") {
           return;
         }
-        // Handle connection timeout errors gracefully
+        // Handle specific database connection errors gracefully
         if (e instanceof Error) {
-          const errorMessage = e.message.toLowerCase();
-          if (errorMessage.includes('timeout') ||
-              errorMessage.includes('connection') ||
-              errorMessage.includes('network')) {
-            console.warn(`${tickID}: Connection issue, will retry on next tick:`, e.message);
+          // Only retry on actual connection errors (not just any error mentioning these words)
+          // Check for specific error patterns from fetch/database failures
+          const isFetchError = e.name === 'TypeError' && e.message.includes('fetch');
+          const isNetworkError = e.name === 'NetworkError';
+          const isTimeoutError = e.name === 'TimeoutError';
+
+          if (isFetchError || isNetworkError || isTimeoutError) {
+            console.warn(`${tickID}: Connection issue (${e.name}), will retry on next tick:`, e.message);
             // Continue the tick loop instead of crashing
             setTimeout(outerTick, intervalMS);
             return;

--- a/web/src/view/hooks/hooks.ts
+++ b/web/src/view/hooks/hooks.ts
@@ -133,6 +133,18 @@ export const useTick = (
         if (e instanceof DOMException && e.name === "AbortError") {
           return;
         }
+        // Handle connection timeout errors gracefully
+        if (e instanceof Error) {
+          const errorMessage = e.message.toLowerCase();
+          if (errorMessage.includes('timeout') ||
+              errorMessage.includes('connection') ||
+              errorMessage.includes('network')) {
+            console.warn(`${tickID}: Connection issue, will retry on next tick:`, e.message);
+            // Continue the tick loop instead of crashing
+            setTimeout(outerTick, intervalMS);
+            return;
+          }
+        }
         throw e;
       } finally {
         console.timeEnd(tickID);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large AnalystChat state/streaming changes affect persisted chat UX and in-flight requests, but changes are confined to the web analyst UI and simulator polling resilience.
> 
> **Overview**
> **Aura Analyst** now shows **live chain-of-thought** while a question is in flight: reasoning and SQL steps stream into a placeholder assistant message (with rotating status text) instead of a separate bottom spinner. Final answers still replace that placeholder and keep the collapsible reasoning/query history; reasoning text strips redundant `**Reasoning:**` headers.
> 
> The send flow is more defensive: optional message override for **follow-up suggestion buttons** (up to three per result), a **2-minute abort timeout** with a user-visible message, and cleanup of **orphaned `isStreaming` messages** on mount/unmount/clear-chat so persisted Recoil chat state does not get stuck.
> 
> **`AnalystChat`** is mounted from **`App`’s layout** whenever the DB is connected (removed from Analytics-only), so the assistant is available across private routes. Recoil message types gain streaming fields; the SSE client adds **chunk progress logging**. Simulator **`useTick`** retries on fetch/network/timeout errors instead of failing the tick loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2389c45994adce0d243910642373f6f01989548d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->