### PR TITLE
Persist Aura Analyst chat size across all tabs

### DIFF
--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -41,7 +41,7 @@ import {
   AnalystChart,
   AnalystTable,
 } from "@/data/analystClient";
-import { analystApiKey, analystEndpointUrl, analystChatOpen, analystChatMessages, analystSessionId } from "@/data/recoil";
+import { analystApiKey, analystEndpointUrl, analystChatOpen, analystChatMessages, analystSessionId, analystChatSize } from "@/data/recoil";
 
 const Plot = createPlotlyComponent(Plotly);
 
@@ -93,7 +93,7 @@ export const AnalystChat: React.FC = () => {
   const [isLoading, setIsLoading] = React.useState(false);
   const [currentThinkingStatus, setCurrentThinkingStatus] = React.useState("Thinking");
   const abortControllerRef = React.useRef<AbortController | null>(null);
-  const [size, setSize] = React.useState({ width: 450, height: 600 });
+  const [size, setSize] = useRecoilState(analystChatSize);
   const [isResizing, setIsResizing] = React.useState(false);
   const isMountedRef = React.useRef(true);
   const isProcessingRef = React.useRef(false);

--- a/web/src/data/recoil.ts
+++ b/web/src/data/recoil.ts
@@ -252,3 +252,9 @@ export const analystSessionId = atom({
   default: crypto.randomUUID(),
   effects: [localStorageEffect()],
 });
+
+export const analystChatSize = atom({
+  key: "analystChatSize",
+  default: { width: 450, height: 600 },
+  effects: [localStorageEffect()],
+});


### PR DESCRIPTION
Move chat size from local useState to Recoil atom with localStorage. Fixes issue where navigating to/from Configure page resets chat size.

Changes:
- Add analystChatSize atom to recoil.ts with localStorage effect
- Replace useState with useRecoilState in AnalystChat component
- Chat size now persists across all page navigation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only state persistence with no auth, API, or data-path changes.
> 
> **Overview**
> **Aura Analyst chat dimensions** no longer reset when you leave a page (e.g. Configure) and come back.
> 
> Chat **width/height** moved from component `useState` to a new **`analystChatSize`** Recoil atom with the same **localStorage** persistence as other analyst UI state (`analystChatOpen`, messages, session). Resizing still updates `setSize`; values now survive route changes and reloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e75aeda4b232f052185caf14f0e76dab490cb9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->