### PR TITLE
Add hover-activated Ask Aura buttons to Analytics stat panels

### DIFF
--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -156,8 +156,7 @@ export const AnalystChat: React.FC = () => {
 
   // Handle pending questions from external triggers (e.g., Ask Aura buttons)
   React.useEffect(() => {
-    if (pendingQuestion && !isLoading && !isProcessingRef.current) {
-      console.log('[Analyst] Processing pending question:', pendingQuestion);
+    if (pendingQuestion && !isLoading && !isProcessingRef.current && apiKey && endpointUrl) {
       handleSend(pendingQuestion).then((sent) => {
         // Only clear pending question if message was actually sent
         if (sent) {
@@ -165,7 +164,7 @@ export const AnalystChat: React.FC = () => {
         }
       });
     }
-  }, [pendingQuestion, isLoading]);
+  }, [pendingQuestion, isLoading, apiKey, endpointUrl]);
 
   // Keep session ID ref in sync with Recoil state
   React.useEffect(() => {
@@ -321,7 +320,7 @@ export const AnalystChat: React.FC = () => {
       // Ignore response if session has changed (chat was cleared)
       if (requestSessionId !== currentSessionIdRef.current) {
         console.log('[Analyst] Session changed, ignoring response');
-        return;
+        return true; // Message was sent, just session changed
       }
 
       if (!isMountedRef.current) {
@@ -336,7 +335,7 @@ export const AnalystChat: React.FC = () => {
           }
           return updated;
         });
-        return;
+        return true; // Message was sent, just component unmounted
       }
 
       console.log('[Analyst] Response results:', response.results?.length || 0);
@@ -417,13 +416,13 @@ export const AnalystChat: React.FC = () => {
           }
           return updated;
         });
-        return;
+        return true; // Message was sent, just component unmounted
       }
 
       // Ignore errors if session changed (chat was cleared)
       if (requestSessionId !== currentSessionIdRef.current) {
         console.log('[Analyst] Session changed, ignoring error');
-        return;
+        return true; // Message was sent, just session changed
       }
 
       // Handle aborted requests
@@ -458,7 +457,7 @@ export const AnalystChat: React.FC = () => {
             return updated;
           });
         }
-        return;
+        return true; // Message was sent, just aborted
       }
 
       // Remove streaming message and show error

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -822,13 +822,40 @@ export const AnalystChat: React.FC = () => {
               </VStack>
             )}
             {messages.length === 0 && apiKey && endpointUrl && (
-              <Text color="gray.500" textAlign="center" mt={8}>
-                Ask me anything about your MarTech campaign data!
-                <br />
-                <br />
-                Try: "What are the top performing campaigns?" or "Show me
-                conversion rates by city"
-              </Text>
+              <VStack spacing={3} mt={8}>
+                <Text color="gray.500" fontWeight="medium">
+                  Get started with these questions:
+                </Text>
+                <VStack spacing={2} w="100%">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    colorScheme="purple"
+                    w="90%"
+                    onClick={() => handleSend("What are the top performing campaigns?")}
+                  >
+                    What are the top performing campaigns?
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    colorScheme="purple"
+                    w="90%"
+                    onClick={() => handleSend("Show me conversion rates by city")}
+                  >
+                    Show me conversion rates by city
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    colorScheme="purple"
+                    w="90%"
+                    onClick={() => handleSend("Which customers have the highest ROAS?")}
+                  >
+                    Which customers have the highest ROAS?
+                  </Button>
+                </VStack>
+              </VStack>
             )}
             {messages.map((msg, idx) => (
               <Flex

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -158,8 +158,12 @@ export const AnalystChat: React.FC = () => {
   React.useEffect(() => {
     if (pendingQuestion && !isLoading && !isProcessingRef.current) {
       console.log('[Analyst] Processing pending question:', pendingQuestion);
-      handleSend(pendingQuestion);
-      setPendingQuestion(null);
+      handleSend(pendingQuestion).then((sent) => {
+        // Only clear pending question if message was actually sent
+        if (sent) {
+          setPendingQuestion(null);
+        }
+      });
     }
   }, [pendingQuestion, isLoading]);
 
@@ -218,10 +222,10 @@ export const AnalystChat: React.FC = () => {
 
   const handleSend = async (messageOverride?: string) => {
     const messageToSend = messageOverride || input;
-    if (!messageToSend.trim() || isLoading || isProcessingRef.current) return;
+    if (!messageToSend.trim() || isLoading || isProcessingRef.current) return false;
 
     if (!apiKey || !endpointUrl) {
-      return;
+      return false;
     }
 
     isProcessingRef.current = true;
@@ -483,6 +487,7 @@ export const AnalystChat: React.FC = () => {
         }
       }
     }
+    return true;
   };
 
   const renderData = (result: AnalystQueryResult) => {

--- a/web/src/components/AnalystChat.tsx
+++ b/web/src/components/AnalystChat.tsx
@@ -41,7 +41,7 @@ import {
   AnalystChart,
   AnalystTable,
 } from "@/data/analystClient";
-import { analystApiKey, analystEndpointUrl, analystChatOpen, analystChatMessages, analystSessionId, analystChatSize } from "@/data/recoil";
+import { analystApiKey, analystEndpointUrl, analystChatOpen, analystChatMessages, analystSessionId, analystChatSize, analystPendingQuestion } from "@/data/recoil";
 
 const Plot = createPlotlyComponent(Plotly);
 
@@ -89,6 +89,7 @@ export const AnalystChat: React.FC = () => {
   const [isOpen, setIsOpen] = useRecoilState(analystChatOpen);
   const [messages, setMessages] = useRecoilState(analystChatMessages);
   const [sessionId, setSessionId] = useRecoilState(analystSessionId);
+  const [pendingQuestion, setPendingQuestion] = useRecoilState(analystPendingQuestion);
   const [input, setInput] = React.useState("");
   const [isLoading, setIsLoading] = React.useState(false);
   const [currentThinkingStatus, setCurrentThinkingStatus] = React.useState("Thinking");
@@ -152,6 +153,15 @@ export const AnalystChat: React.FC = () => {
       }
     };
   }, [isLoading]);
+
+  // Handle pending questions from external triggers (e.g., Ask Aura buttons)
+  React.useEffect(() => {
+    if (pendingQuestion && !isLoading && !isProcessingRef.current) {
+      console.log('[Analyst] Processing pending question:', pendingQuestion);
+      handleSend(pendingQuestion);
+      setPendingQuestion(null);
+    }
+  }, [pendingQuestion, isLoading]);
 
   // Keep session ID ref in sync with Recoil state
   React.useEffect(() => {

--- a/web/src/components/AskAuraButton.tsx
+++ b/web/src/components/AskAuraButton.tsx
@@ -1,0 +1,48 @@
+import { IconButton, Tooltip, useColorModeValue } from "@chakra-ui/react";
+import * as React from "react";
+import { FiMessageSquare } from "react-icons/fi";
+import { useSetRecoilState } from "recoil";
+
+import { analystChatOpen, analystPendingQuestion } from "@/data/recoil";
+
+interface AskAuraButtonProps {
+  question: string;
+}
+
+export const AskAuraButton: React.FC<AskAuraButtonProps> = ({
+  question,
+}) => {
+  const setIsOpen = useSetRecoilState(analystChatOpen);
+  const setPendingQuestion = useSetRecoilState(analystPendingQuestion);
+  const buttonBg = useColorModeValue("purple.500", "purple.400");
+  const buttonHoverBg = useColorModeValue("purple.600", "purple.500");
+
+  const handleClick = () => {
+    setIsOpen(true);
+    setPendingQuestion(question);
+  };
+
+  return (
+    <Tooltip label="Ask Aura about this" placement="left" hasArrow>
+      <IconButton
+        aria-label="Ask Aura about this"
+        icon={<FiMessageSquare />}
+        size="sm"
+        bg={buttonBg}
+        color="white"
+        _hover={{ bg: buttonHoverBg }}
+        onClick={handleClick}
+        position="absolute"
+        top={2}
+        right={2}
+        opacity={0}
+        transition="opacity 0.2s"
+        sx={{
+          ".chart-container:hover &": {
+            opacity: 1,
+          },
+        }}
+      />
+    </Tooltip>
+  );
+};

--- a/web/src/components/AskAuraButton.tsx
+++ b/web/src/components/AskAuraButton.tsx
@@ -14,8 +14,8 @@ export const AskAuraButton: React.FC<AskAuraButtonProps> = ({
 }) => {
   const setIsOpen = useSetRecoilState(analystChatOpen);
   const setPendingQuestion = useSetRecoilState(analystPendingQuestion);
-  const buttonBg = useColorModeValue("purple.500", "purple.400");
-  const buttonHoverBg = useColorModeValue("purple.600", "purple.500");
+  const iconColor = useColorModeValue("purple.500", "purple.400");
+  const iconHoverColor = useColorModeValue("purple.600", "purple.500");
 
   const handleClick = () => {
     setIsOpen(true);
@@ -28,20 +28,13 @@ export const AskAuraButton: React.FC<AskAuraButtonProps> = ({
         aria-label="Ask Aura about this"
         icon={<FiMessageSquare />}
         size="sm"
-        bg={buttonBg}
-        color="white"
-        _hover={{ bg: buttonHoverBg }}
+        variant="ghost"
+        color={iconColor}
+        _hover={{ color: iconHoverColor, bg: "transparent" }}
         onClick={handleClick}
         position="absolute"
         top={2}
         right={2}
-        opacity={0}
-        transition="opacity 0.2s"
-        sx={{
-          ".chart-container:hover &": {
-            opacity: 1,
-          },
-        }}
       />
     </Tooltip>
   );

--- a/web/src/data/recoil.ts
+++ b/web/src/data/recoil.ts
@@ -258,3 +258,8 @@ export const analystChatSize = atom({
   default: { width: 450, height: 600 },
   effects: [localStorageEffect()],
 });
+
+export const analystPendingQuestion = atom<string | null>({
+  key: "analystPendingQuestion",
+  default: null,
+});

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -36,6 +36,7 @@ import { MdAttachMoney, MdMonetizationOn } from "react-icons/md";
 import { useRecoilValue } from "recoil";
 import useSWR from "swr";
 
+import { AskAuraButton } from "@/components/AskAuraButton";
 import { Loader } from "@/components/customcomponents/loader/Loader";
 import { EnableSimulatorWarning } from "@/components/EnableSimulatorButton";
 import { Heatmap } from "@/components/HeatMap";
@@ -194,24 +195,29 @@ const StatGrid = () => {
         statLabel="Ad Campaigns"
         statNumber={formatStat(tableCounts.data.offers)}
         colSpan={2}
+        askAuraQuestion="How many active ad campaigns are running and which customers have the most campaigns?"
       />
       <StatWrapper
         statLabel="Audience Segments"
         statNumber={formatStat(tableCounts.data.subscribers)}
+        askAuraQuestion="What are the largest audience segments and how are subscribers distributed across them?"
       />
       <StatWrapper
         statLabel="Notifications"
         statNumber={formatStat(tableCounts.data.notifications)}
+        askAuraQuestion="What's the trend in notifications over time and which campaigns are generating the most?"
       />
       <StatWrapper
         statLabel="Conversion Rate"
         statNumber={formatPct(overallRateRequests.data?.conversionRate || 0)}
         helpText="Requests"
+        askAuraQuestion="What's the conversion rate trend and which campaigns have the highest conversion rates?"
       />
       <StatWrapper
         statLabel="Conversion Rate"
         statNumber={formatPct(overallRatePurchases.data?.conversionRate || 0)}
         helpText="Purchases"
+        askAuraQuestion="How does purchase conversion rate vary by campaign and market?"
       />
     </Grid>
   );
@@ -430,11 +436,13 @@ const StatWrapper = ({
   statNumber,
   helpText,
   colSpan,
+  askAuraQuestion,
 }: {
   statLabel: string;
   statNumber: string;
   helpText?: string;
   colSpan?: number;
+  askAuraQuestion?: string;
 }) => {
   let helpTextContainer;
   if (helpText) {
@@ -447,7 +455,10 @@ const StatWrapper = ({
       background={useColorModeValue("#ECE8FD", "#360061")}
       borderRadius="15px"
       colSpan={colSpan || 1}
+      position="relative"
+      className="chart-container"
     >
+      {askAuraQuestion && <AskAuraButton question={askAuraQuestion} />}
       <Stat>
         <StatLabel>{statLabel}</StatLabel>
         <StatNumber color={useColorModeValue("#820DDF", "#D199FF")}>


### PR DESCRIPTION
- Create AskAuraButton component with hover-reveal interaction
- Add analystPendingQuestion atom for cross-component question triggering
- Enhance AnalystChat to auto-send pending questions
- Add contextual questions to 5 stat panels in Analytics dashboard

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only integration via Recoil; no auth or backend changes. Main risk is edge-case double-sends or stale pending questions if chat is busy, mitigated by loading/processing guards.
> 
> **Overview**
> Adds **Ask Aura** entry points on the Analytics dashboard so users can open Aura Analyst with a **pre-filled, contextual question** tied to each stat tile.
> 
> A new **`AskAuraButton`** sets `analystChatOpen` and writes the question into a shared **`analystPendingQuestion`** Recoil atom. **`AnalystChat`** watches that atom and auto-sends when the chat is idle and analyst credentials are configured; **`handleSend`** now returns a boolean so pending state is cleared only when a send actually starts (not when blocked by loading or missing config).
> 
> Five **`StatWrapper`** panels pass tailored `askAuraQuestion` strings (campaigns, segments, notifications, conversion rates). The empty-chat state also replaces static example text with **clickable starter question buttons**, including a third ROAS prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9652afd626e77c20b0e0c6c55b9c9a682a856b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->