### PR TITLE
Fix Ask Aura button overlap on narrow stat panels

### DIFF
--- a/web/src/components/AskAuraButton.tsx
+++ b/web/src/components/AskAuraButton.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Tooltip, useColorModeValue } from "@chakra-ui/react";
+import { IconButton, Tooltip, useColorModeValue, useBreakpointValue } from "@chakra-ui/react";
 import * as React from "react";
 import { FiMessageSquare } from "react-icons/fi";
 import { useSetRecoilState } from "recoil";
@@ -7,20 +7,29 @@ import { analystChatOpen, analystPendingQuestion } from "@/data/recoil";
 
 interface AskAuraButtonProps {
   question: string;
+  colSpan?: number;
 }
 
 export const AskAuraButton: React.FC<AskAuraButtonProps> = ({
   question,
+  colSpan = 1,
 }) => {
   const setIsOpen = useSetRecoilState(analystChatOpen);
   const setPendingQuestion = useSetRecoilState(analystPendingQuestion);
   const iconColor = useColorModeValue("purple.500", "purple.400");
   const iconHoverColor = useColorModeValue("purple.600", "purple.500");
 
+  // Hide button on narrow panels (colSpan 1) when screen is small
+  const shouldShow = useBreakpointValue({ base: colSpan > 1, md: true });
+
   const handleClick = () => {
     setIsOpen(true);
     setPendingQuestion(question);
   };
+
+  if (!shouldShow) {
+    return null;
+  }
 
   return (
     <Tooltip label="Ask Aura about this" placement="left" hasArrow>

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -458,7 +458,7 @@ const StatWrapper = ({
       position="relative"
       className="chart-container"
     >
-      {askAuraQuestion && <AskAuraButton question={askAuraQuestion} />}
+      {askAuraQuestion && <AskAuraButton question={askAuraQuestion} colSpan={colSpan} />}
       <Stat>
         <StatLabel>{statLabel}</StatLabel>
         <StatNumber color={useColorModeValue("#820DDF", "#D199FF")}>


### PR DESCRIPTION
- Hide Ask Aura buttons on single-column panels on small screens
- Show all buttons on medium screens and larger
- Pass colSpan to AskAuraButton for responsive behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small responsive UI change with no auth, data, or API impact; only affects visibility of an existing chat shortcut on Analytics.
> 
> **Overview**
> Fixes **Ask Aura** icon overlap on cramped Analytics stat tiles by making the button responsive to panel width.
> 
> `AskAuraButton` now accepts an optional **`colSpan`** (default `1`). On **`base`** viewports it renders only when `colSpan > 1`; from **`md`** up it always shows. **`StatWrapper`** in `Analytics.tsx` passes through the grid **`colSpan`** so full-width stats (e.g. Ad Campaigns with `colSpan={2}`) keep the button on phones while single-column stats hide it until the layout is wider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2674e7e7cf6fc0e8aa64d1f31be189a6213e697a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->