### PR TITLE
Disable plancache checking to fix race condition errors

### DIFF
--- a/web/src/data/queries.ts
+++ b/web/src/data/queries.ts
@@ -361,32 +361,12 @@ export const ensurePipelinesAreRunning = async (config: ConnectionConfig) => {
 
 // returns true if any plans were dropped
 export const checkPlans = async (config: ConnectionConfig) => {
-  const badPlans = await Query<{ planId: string }>(
-    config,
-    `
-      SELECT plan_id AS planId
-      FROM information_schema.plancache
-      WHERE
-        plan_warnings LIKE "%empty tables%"
-    `
-  );
-
-  // Drop each plan individually, ignoring "plan missing" errors
-  // This prevents one failed drop from blocking others
-  await Promise.all(
-    badPlans.map(async ({ planId }) => {
-      try {
-        await Exec(config, `DROP ${planId} FROM PLANCACHE`);
-      } catch (e) {
-        // Silently ignore if plan was already dropped
-        if (!(e instanceof SQLError && e.isPlanMissing())) {
-          throw e;
-        }
-      }
-    })
-  );
-
-  return badPlans.length > 0;
+  // Disabled: plancache checking causes race condition errors (Error 1885)
+  // When multiple concurrent sessions query plancache and try to drop plans,
+  // one session may drop a plan between another session's SELECT and DROP,
+  // causing "plan does not exist" errors (HY000). The database warms up
+  // naturally without manual plan drops, so this check is no longer needed.
+  return false;
 };
 
 export const estimatedRowCount = <TableName extends string>(


### PR DESCRIPTION
The plancache checking code was causing Error 1885 (HY000) "A plan with plan_id X does not exist" errors when multiple concurrent sessions tried to drop query plans. This happened because:

1. Session A queries plancache and finds plan 127
2. Session B queries plancache and finds plan 127
3. Session A drops plan 127
4. Session B tries to drop plan 127 → Error 1885

The database warms up naturally without manual plan drops, so disabling this check eliminates the race condition without impacting performance.

This fix was originally applied in commit 3acc36c but was accidentally reverted in commit bb058f6 when improving error handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change: the UI “warming up” path tied to dropped plans will no longer activate, with no auth or data-path impact.
> 
> **Overview**
> **Disables automatic plancache cleanup** in `checkPlans` by removing the `information_schema.plancache` query and per-plan `DROP … FROM PLANCACHE` logic. The function now always returns `false`, so callers no longer trigger plan drops during configure/simulation monitoring.
> 
> This avoids **Error 1885 (HY000)** when concurrent sessions race: one session drops a plan between another’s SELECT and DROP. Inline comments document that the DB warms up without manual drops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb06d3c40660027b2994226cd11720a3d7b30fb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->