### PR TITLE
Akwong/fix run matching process call

### DIFF
--- a/sql/procedures.sql
+++ b/sql/procedures.sql
@@ -54,7 +54,7 @@ END //
 
 CREATE OR REPLACE PROCEDURE run_matching_process (
   _interval ENUM("second", "minute", "hour", "day", "week", "month")
-) RETURNS BIGINT
+)
 AS
 DECLARE
   _ts DATETIME = NOW(6);
@@ -70,7 +70,7 @@ BEGIN
   WHERE ts = _ts
   ON DUPLICATE KEY UPDATE last_notification = _ts;
 
-  RETURN _count;
+  ECHO SELECT _count AS RESULT;
 END //
 
 CREATE OR REPLACE PROCEDURE update_segments (

--- a/web/src/data/queries.ts
+++ b/web/src/data/queries.ts
@@ -361,32 +361,12 @@ export const ensurePipelinesAreRunning = async (config: ConnectionConfig) => {
 
 // returns true if any plans were dropped
 export const checkPlans = async (config: ConnectionConfig) => {
-  const badPlans = await Query<{ planId: string }>(
-    config,
-    `
-      SELECT plan_id AS planId
-      FROM information_schema.plancache
-      WHERE
-        plan_warnings LIKE "%empty tables%"
-    `
-  );
-
-  // Drop each plan individually, ignoring "plan missing" errors
-  // This prevents one failed drop from blocking others
-  await Promise.all(
-    badPlans.map(async ({ planId }) => {
-      try {
-        await Exec(config, `DROP ${planId} FROM PLANCACHE`);
-      } catch (e) {
-        // Silently ignore if plan was already dropped
-        if (!(e instanceof SQLError && e.isPlanMissing())) {
-          throw e;
-        }
-      }
-    })
-  );
-
-  return badPlans.length > 0;
+  // Disabled: plancache checking causes race condition errors (Error 1885)
+  // When multiple concurrent sessions query plancache and try to drop plans,
+  // one session may drop a plan between another session's SELECT and DROP,
+  // causing "plan does not exist" errors (HY000). The database warms up
+  // naturally without manual plan drops, so this check is no longer needed.
+  return false;
 };
 
 export const estimatedRowCount = <TableName extends string>(

--- a/web/src/data/queries.ts
+++ b/web/src/data/queries.ts
@@ -513,7 +513,7 @@ export const runMatchingProcess = (
 ) =>
   QueryOne<{ RESULT: number }>(
     config,
-    "ECHO run_matching_process(?)",
+    "CALL run_matching_process(?)",
     interval
   ).then((x) => x.RESULT);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes stored procedure contract and matching invocation path (core notification flow); plancache cleanup removal may leave stale plans but avoids HY000 races in Configure warmup.
> 
> **Overview**
> Fixes how the app runs the matching job and reads the notification count, and stops aggressive plancache maintenance that was erroring under concurrency.
> 
> **`run_matching_process`** no longer uses a `RETURNS BIGINT` / `RETURN` signature. It now **`ECHO SELECT _count AS RESULT`**, matching other procedures like `update_sessions`. The web layer switches from **`ECHO run_matching_process(?)`** to **`CALL run_matching_process(?)`** and still reads **`RESULT`** from the result set.
> 
> **`checkPlans`** is stubbed to always return `false`. The previous logic that queried `information_schema.plancache` for “empty tables” warnings and dropped plans was removed because concurrent sessions could hit **Error 1885 / “plan does not exist”** between SELECT and DROP; warmup is expected to happen without manual drops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef01b9021900d82ca0006c8d482c359eabd2561. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->