### PR TITLE
Fix run_matching_process to return result via ECHO SELECT

### DIFF
--- a/sql/procedures.sql
+++ b/sql/procedures.sql
@@ -54,7 +54,7 @@ END //
 
 CREATE OR REPLACE PROCEDURE run_matching_process (
   _interval ENUM("second", "minute", "hour", "day", "week", "month")
-) RETURNS BIGINT
+)
 AS
 DECLARE
   _ts DATETIME = NOW(6);
@@ -70,7 +70,7 @@ BEGIN
   WHERE ts = _ts
   ON DUPLICATE KEY UPDATE last_notification = _ts;
 
-  RETURN _count;
+  ECHO SELECT * FROM (SELECT _count AS RESULT) AS result;
 END //
 
 CREATE OR REPLACE PROCEDURE update_segments (


### PR DESCRIPTION
Changed procedure to use ECHO SELECT instead of RETURN to properly return the notification count to the client. CALL with RETURNS BIGINT doesn't expose the return value as a result set, causing QueryOne to fail.

Uses ECHO SELECT * FROM (SELECT _count AS RESULT) pattern to ensure a proper result set is returned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line SQL change in one stored procedure; no auth, data model, or application code changes.
> 
> **Overview**
> Fixes **`run_matching_process`** so the matching notification count is visible to the app after `CALL run_matching_process(?)`.
> 
> The procedure still ends with **`ECHO SELECT`**, but the count is now returned as **`ECHO SELECT * FROM (SELECT _count AS RESULT) AS result`**. That subquery wrapper yields a normal result set with a **`RESULT`** column, which **`runMatchingProcess`** in `queries.ts` reads via **`QueryOne`**—instead of a return value that **`CALL`** does not expose as rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 192172a39b6e6dc16dafe36d62de5e17f3267fb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->