### PR TITLE
Fix run_matching_process to return count via ECHO SELECT

### DIFF
--- a/sql/procedures.sql
+++ b/sql/procedures.sql
@@ -54,7 +54,7 @@ END //
 
 CREATE OR REPLACE PROCEDURE run_matching_process (
   _interval ENUM("second", "minute", "hour", "day", "week", "month")
-) RETURNS BIGINT
+)
 AS
 DECLARE
   _ts DATETIME = NOW(6);
@@ -70,7 +70,7 @@ BEGIN
   WHERE ts = _ts
   ON DUPLICATE KEY UPDATE last_notification = _ts;
 
-  RETURN _count;
+  ECHO SELECT _count AS RESULT;
 END //
 
 CREATE OR REPLACE PROCEDURE update_segments (


### PR DESCRIPTION
Changed from RETURN _count to ECHO SELECT _count AS RESULT. CALL doesn't expose RETURNS values to the client, causing "Expected exactly one row" errors. ECHO SELECT returns a proper result set that QueryOne can read.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to procedure result shaping only; no change to matching logic or client contract beyond equivalent SQL.
> 
> **Overview**
> **`run_matching_process`** now returns the notification count with a direct **`ECHO SELECT _count AS RESULT`** instead of selecting from a wrapped subquery (`SELECT * FROM (SELECT _count AS RESULT) AS result`).
> 
> Behavior for callers such as **`runMatchingProcess`** in `queries.ts` is unchanged: **`CALL run_matching_process(?)`** still yields a single row with a **`RESULT`** column that **`QueryOne`** reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94f7495bfa895cfb94df76962d7229760ea57942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->