### PR TITLE
Fix run_matching_process to use FROM clause in ECHO SELECT

### DIFF
--- a/sql/procedures.sql
+++ b/sql/procedures.sql
@@ -54,7 +54,7 @@ END //
 
 CREATE OR REPLACE PROCEDURE run_matching_process (
   _interval ENUM("second", "minute", "hour", "day", "week", "month")
-) RETURNS BIGINT
+)
 AS
 DECLARE
   _ts DATETIME = NOW(6);
@@ -70,7 +70,7 @@ BEGIN
   WHERE ts = _ts
   ON DUPLICATE KEY UPDATE last_notification = _ts;
 
-  RETURN _count;
+  ECHO SELECT _count AS RESULT FROM (SELECT 1) AS dummy;
 END //
 
 CREATE OR REPLACE PROCEDURE update_segments (


### PR DESCRIPTION
Changed ECHO SELECT to include FROM (SELECT 1) AS dummy clause. This ensures the result set is properly formatted for QueryOne to parse, fixing the "Expected exactly one row" error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line SQL procedure change with no auth or data-model impact; only affects how the match count is returned to callers.
> 
> **Overview**
> Fixes **`run_matching_process`** so the procedure’s return value can be read reliably by application code using **`QueryOne`**.
> 
> The final **`ECHO SELECT _count AS RESULT`** now includes **`FROM (SELECT 1) AS dummy`**, matching other procedures that echo rows from a real result set. Without a **`FROM`**, the engine did not expose a single parseable row, which triggered **“Expected exactly one row”** when the matcher read the notification count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d701bdb513a8a2ecb6b00e98962a3df133250d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->