### PR TITLE
Fix toLocaleString error when table counts are undefined

### DIFF
--- a/web/src/format.ts
+++ b/web/src/format.ts
@@ -3,8 +3,12 @@ const MINUTE_IN_MS = 60 * SECOND_IN_MS;
 const HOUR_IN_MS = 60 * MINUTE_IN_MS;
 const DAY_IN_MS = 24 * HOUR_IN_MS;
 
-export const formatNumber = (num: number): string =>
-  num.toLocaleString(undefined, { maximumFractionDigits: 2 });
+export const formatNumber = (num: number | undefined): string => {
+  if (num === undefined || num === null || isNaN(num)) {
+    return "0";
+  }
+  return num.toLocaleString(undefined, { maximumFractionDigits: 2 });
+};
 
 // formatMs converts a number of milliseconds to a string of the form "XhXXmXXsXXms"
 export const formatMs = (ms?: number): string => {

--- a/web/src/pages/Configure.tsx
+++ b/web/src/pages/Configure.tsx
@@ -747,7 +747,7 @@ const SegmentationSection = ({
     const { segments, subscriber_segments, locations, requests, purchases } =
       tableCounts.data;
     const durationFormatted = formatMs(elapsed);
-    const estRows = formatNumber(locations + requests + purchases);
+    const estRows = formatNumber((locations || 0) + (requests || 0) + (purchases || 0));
     const seg = formatNumber(segments);
     const memberships = formatNumber(subscriber_segments);
 
@@ -881,7 +881,7 @@ const MatchingSection = ({
   if (elapsed && tableCounts.data) {
     const { offers, subscribers, subscriber_segments, notifications } =
       tableCounts.data;
-    const estRows = formatNumber(offers * subscribers + notifications);
+    const estRows = formatNumber((offers || 0) * (subscribers || 0) + (notifications || 0));
     const memberships = formatNumber(subscriber_segments);
     const durationFormatted = formatMs(elapsed);
     const sentNotifs = formatNumber(sentNotifications);


### PR DESCRIPTION
## Summary
- Fixed error: "Cannot read properties of undefined (reading 'toLocaleString')" in Matching section
- Added defensive checks in `formatNumber()` to handle undefined/null/NaN values
- Added nullish coalescing operators when computing work estimates in Configure page

## Root Cause
When clicking "Generate notifications", if table counts (offers, subscribers, etc.) are undefined, the app tries to call `.toLocaleString()` on undefined, causing the error.

## Changes
- `web/src/format.ts`: Added null/undefined checks in `formatNumber()`
- `web/src/pages/Configure.tsx`: Added `|| 0` fallbacks when computing estimates

## Test plan
- [ ] Click "Generate notifications" in Matching section
- [ ] Verify no error appears
- [ ] Confirm work estimate displays correctly (even with 0 values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI formatting and defensive SQL/procedure call fixes with no auth or data-model changes; CALL vs ECHO is the only behavioral DB change and matches existing procedure usage.
> 
> **Overview**
> Fixes a crash when **Generate notifications** (or segmentation work estimates) runs before table counts are fully populated, by making number formatting and estimate math tolerate missing values.
> 
> **`formatNumber`** now accepts `undefined` and returns `"0"` for undefined, null, or NaN instead of calling `toLocaleString` on bad inputs. The Configure **Segmentation** and **Matching** work-estimate lines use `|| 0` when summing or multiplying row counts so arithmetic never feeds undefined into formatting.
> 
> Separately, **`checkPlans`** drops bad plancache entries one at a time so a single “plan missing” error no longer aborts the rest of the drops. **`runMatchingProcess`** invokes the database with `CALL run_matching_process(?)` instead of `ECHO`, aligning with how other procedures (e.g. `update_segments`) are run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba7720425c317b69945f5104d1a4be27f3f99b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->